### PR TITLE
[Composer][Travis] Drop PHP version 5.5, travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,9 @@ env:
 
 matrix:
   exclude:
-    - php: 7.0
-      env: DOCTRINE_CACHE_DRIVER="redis"
     - php: hhvm
       env: DOCTRINE_CACHE_DRIVER="redis"
   include:
-    - php: 7.0
-      env: DOCTRINE_CACHE_DRIVER="array"
     - php: hhvm
       env: DOCTRINE_CACHE_DRIVER="array"
   allow_failures:
@@ -32,9 +28,10 @@ matrix:
   fast_finish: true
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION =~ 5.6 ]] ; then echo 'extension="redis.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
-  - if [[ $TRAVIS_PHP_VERSION =~ 5.6 ]] ; then cat ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini|grep redis; fi;
+  - if [[ $TRAVIS_PHP_VERSION != hhvm ]] ; then echo 'extension="redis.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+  - if [[ $TRAVIS_PHP_VERSION != hhvm ]] ; then cat ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini|grep redis; fi;
   - phpenv rehash
+  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
   - composer install --no-interaction --prefer-source
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
   - redis-server
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
@@ -33,8 +32,8 @@ matrix:
   fast_finish: true
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then echo 'extension="redis.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
-  - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then cat ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini|grep redis; fi;
+  - if [[ $TRAVIS_PHP_VERSION =~ 5.6 ]] ; then echo 'extension="redis.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+  - if [[ $TRAVIS_PHP_VERSION =~ 5.6 ]] ; then cat ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini|grep redis; fi;
   - phpenv rehash
   - composer install --no-interaction --prefer-source
 

--- a/app/check.php
+++ b/app/check.php
@@ -80,7 +80,7 @@ function get_error_message(Requirement $requirement, $lineSize)
         return;
     }
 
-    $errorMessage  = wordwrap($requirement->getTestMessage(), $lineSize - 3, PHP_EOL.'   ').PHP_EOL;
+    $errorMessage = wordwrap($requirement->getTestMessage(), $lineSize - 3, PHP_EOL.'   ').PHP_EOL;
     $errorMessage .= '   > '.wordwrap($requirement->getHelpText(), $lineSize - 5, PHP_EOL.'   > ').PHP_EOL;
 
     return $errorMessage;
@@ -121,8 +121,8 @@ function echo_block($style, $title, $message)
     echo PHP_EOL.PHP_EOL;
 
     echo_style($style, str_repeat(' ', $width).PHP_EOL);
-    echo_style($style, str_pad(' ['.$title.']',  $width, ' ', STR_PAD_RIGHT).PHP_EOL);
-    echo_style($style, str_pad($message,  $width, ' ', STR_PAD_RIGHT).PHP_EOL);
+    echo_style($style, str_pad(' ['.$title.']', $width, ' ', STR_PAD_RIGHT).PHP_EOL);
+    echo_style($style, str_pad($message, $width, ' ', STR_PAD_RIGHT).PHP_EOL);
     echo_style($style, str_repeat(' ', $width).PHP_EOL);
 }
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         }
     ],
     "require": {
-		    "php": "^5.6|^7.0",
+        "php": "^5.6|^7.0",
         "symfony/symfony": "2.8.x-dev",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.11",
+		    "php": "^5.6|^7.0",
         "symfony/symfony": "2.8.x-dev",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2f79f376f5647595cf0c362b5428974d",
-    "content-hash": "f9e58def753da2b62e7305b4be4133b0",
+    "hash": "4bf200b8873af65d5eee3de3ed74b373",
+    "content-hash": "8867b90849eb3f8b04ebedb0b6fdf30f",
     "packages": [
         {
             "name": "ahilles107/updater",
@@ -6642,7 +6642,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5.11"
+        "php": "^5.6|^7.0"
     },
     "platform-dev": []
 }

--- a/src/SWP/Bundle/BridgeBundle/Client/GuzzleApiClient.php
+++ b/src/SWP/Bundle/BridgeBundle/Client/GuzzleApiClient.php
@@ -11,7 +11,6 @@
  * @copyright 2015 Sourcefabric z.ú.
  * @license http://www.superdesk.org/license
  */
-
 namespace SWP\Bundle\BridgeBundle\Client;
 
 use Superdesk\ContentApiSdk\Api\Request\RequestInterface;

--- a/src/SWP/Bundle/BridgeBundle/Client/GuzzleClient.php
+++ b/src/SWP/Bundle/BridgeBundle/Client/GuzzleClient.php
@@ -11,14 +11,12 @@
  * @copyright 2015 Sourcefabric z.ú.
  * @license http://www.superdesk.org/license
  */
-
 namespace SWP\Bundle\BridgeBundle\Client;
 
 use GuzzleHttp\Client as BaseClient;
 use GuzzleHttp\Exception\ClientException as GuzzleClientException;
 use GuzzleHttp\Exception\ServerException as GuzzleServerException;
 use GuzzleHttp\Exception\TransferException as GuzzleTransferException;
-use Superdesk\ContentApiSdk\ContentApiSdk;
 use Superdesk\ContentApiSdk\Client\ClientInterface;
 use Superdesk\ContentApiSdk\Exception\ClientException;
 
@@ -60,7 +58,7 @@ class GuzzleClient extends BaseClient implements ClientInterface
         $responseArray = array(
             'headers' => $response->getHeaders(),
             'status' => $response->getStatusCode(),
-            'body' => (string) $response->getBody()
+            'body' => (string) $response->getBody(),
         );
 
         return $responseArray;

--- a/src/SWP/Bundle/BridgeBundle/Controller/BridgeController.php
+++ b/src/SWP/Bundle/BridgeBundle/Controller/BridgeController.php
@@ -11,7 +11,6 @@
  * @copyright 2015 Sourcefabric z.ú.
  * @license http://www.superdesk.org/license
  */
-
 namespace SWP\Bundle\BridgeBundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;

--- a/src/SWP/Bundle/BridgeBundle/DependencyInjection/Configuration.php
+++ b/src/SWP/Bundle/BridgeBundle/DependencyInjection/Configuration.php
@@ -11,7 +11,6 @@
  * @copyright 2015 Sourcefabric z.ú.
  * @license http://www.superdesk.org/license
  */
-
 namespace SWP\Bundle\BridgeBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/SWP/Bundle/BridgeBundle/DependencyInjection/SWPBridgeExtension.php
+++ b/src/SWP/Bundle/BridgeBundle/DependencyInjection/SWPBridgeExtension.php
@@ -11,13 +11,10 @@
  * @copyright 2015 Sourcefabric z.ú.
  * @license http://www.superdesk.org/license
  */
-
 namespace SWP\Bundle\BridgeBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Loader;
 
 /**
  * This is the class that loads and manages your bundle configuration.
@@ -49,6 +46,6 @@ class SWPBridgeExtension extends Extension
         if (isset($config['options']) && is_array($config['options'])) {
             $defaultOptions = $config['options'];
         }
-        $container->setParameter($this->getAlias() . '.options', $defaultOptions);
+        $container->setParameter($this->getAlias().'.options', $defaultOptions);
     }
 }

--- a/src/SWP/Bundle/BridgeBundle/SWPBridgeBundle.php
+++ b/src/SWP/Bundle/BridgeBundle/SWPBridgeBundle.php
@@ -11,7 +11,6 @@
  * @copyright 2015 Sourcefabric z.ú.
  * @license http://www.superdesk.org/license
  */
-
 namespace SWP\Bundle\BridgeBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/src/SWP/Bundle/BridgeBundle/Tests/DependencyInjection/SWPBridgeExtensionTest.php
+++ b/src/SWP/Bundle/BridgeBundle/Tests/DependencyInjection/SWPBridgeExtensionTest.php
@@ -11,7 +11,6 @@
  * @copyright 2015 Sourcefabric z.ú.
  * @license http://www.superdesk.org/license
  */
-
 namespace SWP\Bundle\BridgeBundle\Tests\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -34,7 +33,7 @@ class SWPBridgeExtensionTest extends \PHPUnit_Framework_TestCase
             'swp_bridge.auth.client_id' => 'my_client_id',
             'swp_bridge.auth.username' => 'my_username',
             'swp_bridge.auth.password' => 'my_password',
-            'swp_bridge.options' => array('curl' => 'dummy')
+            'swp_bridge.options' => array('curl' => 'dummy'),
         );
 
         $container = $this->createContainer($data);
@@ -119,16 +118,16 @@ class SWPBridgeExtensionTest extends \PHPUnit_Framework_TestCase
             'api' => array(
                 'host' => 'example.com',
                 'port' => 8000,
-                'protocol' => 'http'
+                'protocol' => 'http',
             ),
             'auth' => array(
                 'client_id' => 'my_client_id',
                 'username' => 'my_username',
-                'password' => 'my_password'
+                'password' => 'my_password',
             ),
             'options' => array(
-                'curl' => 'dummy'
-            )
+                'curl' => 'dummy',
+            ),
         );
     }
 

--- a/src/SWP/Bundle/BridgeBundle/spec/Client/GuzzleApiClientSpec.php
+++ b/src/SWP/Bundle/BridgeBundle/spec/Client/GuzzleApiClientSpec.php
@@ -11,7 +11,6 @@
  * @copyright 2015 Sourcefabric z.ú.
  * @license http://www.superdesk.org/license
  */
-
 namespace spec\SWP\Bundle\BridgeBundle\Client;
 
 use PhpSpec\ObjectBehavior;

--- a/src/SWP/Bundle/BridgeBundle/spec/Client/GuzzleClientSpec.php
+++ b/src/SWP/Bundle/BridgeBundle/spec/Client/GuzzleClientSpec.php
@@ -11,7 +11,6 @@
  * @copyright 2015 Sourcefabric z.ú.
  * @license http://www.superdesk.org/license
  */
-
 namespace spec\SWP\Bundle\BridgeBundle\Client;
 
 use PhpSpec\ObjectBehavior;
@@ -42,7 +41,7 @@ class GuzzleClientSpec extends ObjectBehavior
     {
         $headers = array(
             'Authorization: some authorization token',
-            'X-Custom-Header: Blaat blaat'
+            'X-Custom-Header: Blaat blaat',
         );
         $response = $this->makeCall('http://httpbin.org/headers', $headers);
         $response->shouldHaveKey('body');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | AGPLv3


Security support for PHP 5.5 is ending in 1 month, thus we should drop support for it in Web Publisher.
See http://php.net/supported-versions.php


This PR is related to https://github.com/superdesk/web-publisher/pull/72 as some dependencies were failing on PHP 5.5 because of not supported PHP 5.5 version.
