### PR TITLE
Added JMS Translation Bundle, translation strings to index.html in de…

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -28,6 +28,7 @@ class AppKernel extends Kernel
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle(),
             new Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle(),
+            new JMS\TranslationBundle\JMSTranslationBundle(),
 
             new SWP\Bundle\MultiTenancyBundle\SWPMultiTenancyBundle(),
             new SWP\Bundle\TemplateEngineBundle\SWPTemplateEngineBundle(),
@@ -35,7 +36,7 @@ class AppKernel extends Kernel
             new SWP\UpdaterBundle\SWPUpdaterBundle(),
             new SWP\Bundle\BridgeBundle\SWPBridgeBundle(),
             new SWP\Bundle\ContentBundle\SWPContentBundle(),
-            new SWP\Bundle\AnalyticsBundle\SWPAnalyticsBundle(),
+            new SWP\Bundle\AnalyticsBundle\SWPAnalyticsBundle()
         );
 
         if (in_array($this->getEnvironment(), ['dev', 'test'])) {

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -36,7 +36,7 @@ class AppKernel extends Kernel
             new SWP\UpdaterBundle\SWPUpdaterBundle(),
             new SWP\Bundle\BridgeBundle\SWPBridgeBundle(),
             new SWP\Bundle\ContentBundle\SWPContentBundle(),
-            new SWP\Bundle\AnalyticsBundle\SWPAnalyticsBundle()
+            new SWP\Bundle\AnalyticsBundle\SWPAnalyticsBundle(),
         );
 
         if (in_array($this->getEnvironment(), ['dev', 'test'])) {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -9,7 +9,9 @@ parameters:
     locale: en
 framework:
     #esi:             ~
-    translator:      { fallbacks: ["%locale%"] }
+    translator:
+        fallbacks: ["%locale%"]
+        logging: false
     secret:          "%secret%"
     router:
         resource: "%kernel.root_dir%/config/routing.yml"

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -20,6 +20,10 @@ services:
         class: Twig_Extension_Debug
         tags:
                 - { name: 'twig.extension' }
+    data_collector.translation:
+        class: "%data_collector.config.class%"
+        tags:
+           - {name: 'data_collector', priority: '0'}
 
 monolog:
     handlers:

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,8 @@
         "stof/doctrine-extensions-bundle": "^1.2",
         "symfony-cmf/routing-bundle": "^1.3",
         "sylius/theme-bundle": "0.18.x-dev",
-        "superdesk/contentapi-sdk-php": "1.0.x-dev"
+        "superdesk/contentapi-sdk-php": "1.0.x-dev",
+        "jms/translation-bundle": "^1.2"
     },
     "require-dev": {
         "sensio/generator-bundle": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d8249aae272f3737d397d2ed8380f387",
-    "content-hash": "384bc0f11b0418b0b666f117cd6476fa",
+    "hash": "3f123c66b15950d2177aa608572b3b3d",
+    "content-hash": "d9434fa353a794bf82f31a88f9f307bc",
     "packages": [
         {
             "name": "ahilles107/updater",
@@ -1370,7 +1370,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSRestBundle/zipball/bf39f0f902a99169f5f5d42d1db9740e5fc4d2f6",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSRestBundle/zipball/c1b87d933dfc9b59fc603f8e44f8064e4530a2b1",
                 "reference": "bf39f0f902a99169f5f5d42d1db9740e5fc4d2f6",
                 "shasum": ""
             },
@@ -1952,7 +1952,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jackalope/jackalope-doctrine-dbal/zipball/121c087f4ebda828be178dc3cc92fab2e9ffaab6",
+                "url": "https://api.github.com/repos/jackalope/jackalope-doctrine-dbal/zipball/2116bbe24e72a9c4cd22eeb6d7e857ce62de094a",
                 "reference": "121c087f4ebda828be178dc3cc92fab2e9ffaab6",
                 "shasum": ""
             },
@@ -2285,6 +2285,74 @@
                 "xml"
             ],
             "time": "2015-11-10 12:26:42"
+        },
+        {
+            "name": "jms/translation-bundle",
+            "version": "1.2.3",
+            "target-dir": "JMS/TranslationBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/JMSTranslationBundle.git",
+                "reference": "d0d6c7f002e4210217b5f7271a438309d305540a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/JMSTranslationBundle/zipball/d0d6c7f002e4210217b5f7271a438309d305540a",
+                "reference": "d0d6c7f002e4210217b5f7271a438309d305540a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^1.4|^2.0",
+                "php": "^5.3.3|^7.0",
+                "symfony/console": "^2.3|^3.0",
+                "symfony/framework-bundle": "^2.3|^3.0"
+            },
+            "conflict": {
+                "twig/twig": "<1.12"
+            },
+            "require-dev": {
+                "jms/di-extra-bundle": "^1.1",
+                "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
+                "psr/log": "^1.0",
+                "sensio/framework-extra-bundle": "^2.3|^3.0",
+                "symfony/expression-language": "~2.6|~3.0",
+                "symfony/symfony": "^2.3|^3.0",
+                "twig/twig": "^1.12"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "JMS\\TranslationBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Puts the Symfony Translation Component on steroids",
+            "homepage": "http://jmsyst.com/bundles/JMSTranslationBundle",
+            "keywords": [
+                "extract",
+                "extraction",
+                "i18n",
+                "interface",
+                "multilanguage",
+                "translation",
+                "ui",
+                "webinterface"
+            ],
+            "time": "2016-05-08 03:48:49"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -2780,6 +2848,57 @@
                 "rest"
             ],
             "time": "2016-03-21 11:19:12"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "47b254ea51f1d6d5dc04b9b299e88346bf2369e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/47b254ea51f1d6d5dc04b9b299e88346bf2369e3",
+                "reference": "47b254ea51f1d6d5dc04b9b299e88346bf2369e3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2016-04-19 13:41:41"
         },
         {
             "name": "oneup/flysystem-bundle",
@@ -4616,7 +4735,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/5a560f1d12a7ccf55f078542657cd3251f9d0913",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/27f1cfc9afa3b24e481004c08ecefbc47c8103b8",
                 "reference": "5a560f1d12a7ccf55f078542657cd3251f9d0913",
                 "shasum": ""
             },

--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -16,7 +16,7 @@ By default, themes are located under the :code:`app/themes` directory. A basic t
         views/                  <=== Views directory
             home.html.twig
         translations/           <=== Translations directory
-            messages.en.yml
+            messages.en.xlf
         public/                 <=== Assets directory
             css/
             js/
@@ -53,7 +53,7 @@ A theme with device-specific templates could be structured like this:
         views/                      <=== Default templates directory
             home.html.twig
         translations/               <=== Translations directory
-            messages.en.yml
+            messages.en.xlf
         public/                     <=== Assets directory
             css/
             js/
@@ -68,3 +68,20 @@ A theme with device-specific templates could be structured like this:
      More details about theme structure and configuration can be found in the `Sylius Theme Bundle documentation`_.
 
 .. _Sylius Theme Bundle documentation: http://docs.sylius.org/en/latest/bundles/SyliusThemeBundle/your_first_theme.html
+
+Translations
+-------------------------
+
+The Symfony Translation component supports a variety of file formats for translation files, but in accordance with `best practices suggested in the Symfony documentation <https://symfony.com/doc/current/best_practices/i18n.html>`_, the XLIFF file format is preferred. `JMSTranslationBundle <http://jmsyst.com/bundles/JMSTranslationBundle>`_ has been added to the project to facilitate the creation and updating of such files. Translation labels added to Twig and php files can be extracted and added to XLIFF files using a `console command <http://jmsyst.com/bundles/JMSTranslationBundle/master/usage>`_. The use of labels is preferred, with an accompanying description in English to inform a translator what needs to be translated. This description could simply be the English text which is to be displayed, but additional information about context could be provided to help a translator who may just be working with the XLIFF file.
+Here is an example of the preferred syntax in twig files:
+
+.. code-block:: twig
+	{{ 'index.welcome.title'|trans|desc('Welcome to Default Theme!') }}
+
+Here is the console command which can then be used to create or update a XLIFF file:
+
+.. code-block:: bash
+	app/console translation:extract *locale* --dir=./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/ --output-dir=./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/translations
+
+This will create or update a XLIFF file called messages.*locale*.xlf
+

--- a/src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/translations/messages.de.xlf
+++ b/src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/translations/messages.de.xlf
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file date="2016-06-30T11:24:28Z" source-language="en" target-language="de" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="ade47103d2dfbcf01c2b917ece9443dee3e0734f" resname="index.assigned.homepage">
+        <source>Assigned homepage</source>
+        <target state="new">Assigned homepage</target>
+        <jms:reference-file line="19">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="903ec3ebd479b97505fcfda1c727d306234c0e9c" resname="index.authors">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <jms:reference-file line="25">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="f8f928eeea8d47a2fc8e5fd1bbc5d3b41f65c9c9" resname="index.current.details">
+        <source>Current theme details</source>
+        <target state="new">Current theme details</target>
+        <jms:reference-file line="20">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="7bcf1aecf056a7ee44beb34e9738a5edd9273750" resname="index.default_container.header">
+        <source>Default container header</source>
+        <target state="new">Default container header</target>
+        <jms:reference-file line="15">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="0ce598c70ceb80e6096040bab4dddb648d6fe82c" resname="index.default_container.text">
+        <source>Minions ipso voluptate nisi reprehenderit occaecat. Enim hahaha bappleees cillum bappleees. Elit officia daa ullamco. Ullamco bappleees reprehenderit aliqua veniam bananaaaa. Minim sed aaaaaah laboris veniam. Pepete aliqua veniam sit amet quis butt tatata bala tu jiji quis minim.</source>
+        <target state="new">Minions ipso voluptate nisi reprehenderit occaecat. Enim hahaha bappleees cillum bappleees. Elit officia daa ullamco. Ullamco bappleees reprehenderit aliqua veniam bananaaaa. Minim sed aaaaaah laboris veniam. Pepete aliqua veniam sit amet quis butt tatata bala tu jiji quis minim.</target>
+        <jms:reference-file line="16">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="163a30f36f43f69affb78a0df8f4e4f69a9bdbc7" resname="index.description">
+        <source>Description</source>
+        <target state="new">Description</target>
+        <jms:reference-file line="23">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="ababef7656922fada438ff1e116a4e594be383b4" resname="index.name">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <jms:reference-file line="22">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="1f78d19b660baaedadb64042aa0d235e1905a2a5" resname="index.news.header">
+        <source>News</source>
+        <target state="new">News</target>
+        <jms:reference-file line="33">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="fc72a5408a4f4b16ad27cd779673358f4e42b0b7" resname="index.path">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <jms:reference-file line="21">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="5a0bfae81e70d813b57d3620e2cc15eaed7abf81" resname="index.title">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <jms:reference-file line="24">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="88fc798bfeb477159a82a6ffea4d0ef80544858b" resname="index.welcome.text">
+        <source>This is a Demo Theme. Check in action all awesome features provided by Superdesk Web Publisher.</source>
+        <target state="new">This is a Demo Theme. Check in action all awesome features provided by Superdesk Web Publisher.</target>
+        <jms:reference-file line="7">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="657f2c5c77d948f83125462bc890f420c50eee6c" resname="index.welcome.title">
+        <source>Welcome to Default Theme!</source>
+        <target state="new">Welcome to Default Theme!</target>
+        <jms:reference-file line="6">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/translations/messages.en.xlf
+++ b/src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/translations/messages.en.xlf
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file date="2016-06-30T11:24:11Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="ade47103d2dfbcf01c2b917ece9443dee3e0734f" resname="index.assigned.homepage">
+        <source>Assigned homepage</source>
+        <target state="new">Assigned homepage</target>
+        <jms:reference-file line="19">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="903ec3ebd479b97505fcfda1c727d306234c0e9c" resname="index.authors">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <jms:reference-file line="25">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="f8f928eeea8d47a2fc8e5fd1bbc5d3b41f65c9c9" resname="index.current.details">
+        <source>Current theme details</source>
+        <target state="new">Current theme details</target>
+        <jms:reference-file line="20">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="7bcf1aecf056a7ee44beb34e9738a5edd9273750" resname="index.default_container.header">
+        <source>Default container header</source>
+        <target state="new">Default container header</target>
+        <jms:reference-file line="15">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="0ce598c70ceb80e6096040bab4dddb648d6fe82c" resname="index.default_container.text">
+        <source>Minions ipso voluptate nisi reprehenderit occaecat. Enim hahaha bappleees cillum bappleees. Elit officia daa ullamco. Ullamco bappleees reprehenderit aliqua veniam bananaaaa. Minim sed aaaaaah laboris veniam. Pepete aliqua veniam sit amet quis butt tatata bala tu jiji quis minim.</source>
+        <target state="new">Minions ipso voluptate nisi reprehenderit occaecat. Enim hahaha bappleees cillum bappleees. Elit officia daa ullamco. Ullamco bappleees reprehenderit aliqua veniam bananaaaa. Minim sed aaaaaah laboris veniam. Pepete aliqua veniam sit amet quis butt tatata bala tu jiji quis minim.</target>
+        <jms:reference-file line="16">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="163a30f36f43f69affb78a0df8f4e4f69a9bdbc7" resname="index.description">
+        <source>Description</source>
+        <target state="new">Description</target>
+        <jms:reference-file line="23">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="ababef7656922fada438ff1e116a4e594be383b4" resname="index.name">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <jms:reference-file line="22">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="1f78d19b660baaedadb64042aa0d235e1905a2a5" resname="index.news.header">
+        <source>News</source>
+        <target state="new">News</target>
+        <jms:reference-file line="33">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="fc72a5408a4f4b16ad27cd779673358f4e42b0b7" resname="index.path">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <jms:reference-file line="21">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="5a0bfae81e70d813b57d3620e2cc15eaed7abf81" resname="index.title">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <jms:reference-file line="24">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="88fc798bfeb477159a82a6ffea4d0ef80544858b" resname="index.welcome.text">
+        <source>This is a Demo Theme. Check in action all awesome features provided by Superdesk Web Publisher.</source>
+        <target state="new">This is a Demo Theme. Check in action all awesome features provided by Superdesk Web Publisher.</target>
+        <jms:reference-file line="7">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="657f2c5c77d948f83125462bc890f420c50eee6c" resname="index.welcome.title">
+        <source>Welcome to Default Theme!</source>
+        <target state="new">Welcome to Default Theme!</target>
+        <jms:reference-file line="6">./src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig</jms:reference-file>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig
+++ b/src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/views/index.html.twig
@@ -3,8 +3,8 @@
 {% block body %}
     <div class="row">
         <div class="jumbotron" style="margin-top:20px;">
-            <h1 class="display-3">Welcome to Default Theme!</h1>
-            <p class="lead">This is a Demo Theme. Check in action all awesome features provided by Superdesk Web Publisher.</p>
+            <h1 class="display-3">{{ 'index.welcome.title'|trans|desc('Welcome to Default Theme!') }}</h1>
+            <p class="lead">{{ 'index.welcome.text'|trans|desc('This is a Demo Theme. Check in action all awesome features provided by Superdesk Web Publisher.') }}</p>
         </div>
 
         {% container 'container_name' with {
@@ -12,17 +12,17 @@
             'class': 'col-md-8',
             'data': {'custom-key': 'value'}
         }%}
-        <h2>Default container header</h2>
-        <p>Minions ipsum voluptate nisi reprehenderit occaecat. Enim hahaha bappleees cillum bappleees. Elit officia daa ullamco. Ullamco bappleees reprehenderit aliqua veniam bananaaaa. Minim sed aaaaaah laboris veniam. Pepete aliqua veniam sit amet quis butt tatata bala tu jiji quis minim.</p>
+        <h2>{{ 'index.default_container.header'|trans|desc('Default container header') }}</h2>
+        <p>{{ 'index.default_container.text'|trans|desc('Minions ipso voluptate nisi reprehenderit occaecat. Enim hahaha bappleees cillum bappleees. Elit officia daa ullamco. Ullamco bappleees reprehenderit aliqua veniam bananaaaa. Minim sed aaaaaah laboris veniam. Pepete aliqua veniam sit amet quis butt tatata bala tu jiji quis minim.') }}</p>
         {% endcontainer %}
 
-        <p><strong>Assigned homepage:</strong> {{ page.name }} (id: {{ page.id }})</p>
-        <h4><strong>Current theme details:</strong></h4>
-        <p><strong>Path:</strong> {{ theme.path }}</p>
-        <p><strong>Name:</strong> {{ theme.name }}</p>
-        <p><strong>Description:</strong> {{ theme.description }}</p>
-        <p><strong>Title:</strong> {{ theme.title }}</p>
-        <p><strong>Authors:</strong></p>
+        <p><strong>{{ 'index.assigned.homepage'|trans|desc('Assigned homepage') }}:</strong> {{ page.name }} (id: {{ page.id }})</p>
+        <h4><strong>{{ 'index.current.details'|trans|desc('Current theme details') }}:</strong></h4>
+        <p><strong>{{ 'index.path'|trans|desc('Path') }}:</strong> {{ theme.path }}</p>
+        <p><strong>{{ 'index.name'|trans|desc('Name') }}:</strong> {{ theme.name }}</p>
+        <p><strong>{{ 'index.description'|trans|desc('Description') }}:</strong> {{ theme.description }}</p>
+        <p><strong>{{ 'index.title'|trans|desc('Title') }}:</strong> {{ theme.title }}</p>
+        <p><strong>{{ 'index.authors'|trans|desc('Authors') }}:</strong></p>
         <ul>
             {% for author in theme.authors %}
                 <li>{{ author.name }} ({{ author.email }}), {{ author.homepage }}, {{ author.role }}</li>
@@ -30,7 +30,7 @@
         </ul>
 
         <div class="col-md-4">
-        <h2>News</h2>
+        <h2>{{ 'index.news.header'|trans|desc('News') }}</h2>
         <ul>
             {% gimmelist article from articles with {'route': '/news'} %}
             <li><a href="{{ url(article) }}">{{ article.title }} </a></li>
@@ -44,3 +44,4 @@
 <h3>Template code used to render that page <small><a href="#" class="js-toggle-code">show/hide</a></small></h3>
 <pre class="js-template-code" style="display:none;">{{ source(_self.getTemplateName())|escape('html') }}</pre>
 {% endblock %}
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [no]
| New feature?  | [yes]
| BC breaks?    | [no]
| Deprecations? | [no]
| Tests pass?   | [yes]
| Fixed tickets | [SWP-164]
| License       | AGPLv3

…fault theme, and initial xlf file for translation to English and German

The added bundle offers the following functionality: http://jmsyst.com/bundles/JMSTranslationBundle/master/usage
Because of peculiarities in the formatting of the xlf files which it generates, and the verbosity of the cli commands, as we need to use them with Sylius themes, I suggest we consider either doing our own implementation, or extending the bundle. We could also added a twig extension function because the suggested syntax is pretty ugly, I think. I have only so far added translation to index.html.twig, but will change the other files if we decide that this is the solution we want. It does meet our basic requirements, even if we might want to revisit it later to develop one which is more user friendly for long term use.