### PR TITLE
Default theme assigned to default tenant by theme setup command

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,3 +5,4 @@ AUTHORS
  - Rafał Muszyński (takeit)
  - Mark Lewis (thnkloud9)
  - Mischa Gorinskat (m038)
+ - Daniel Read (djbrd-sourcefabric)

--- a/src/SWP/Bundle/FixturesBundle/Command/ThemeSetupCommand.php
+++ b/src/SWP/Bundle/FixturesBundle/Command/ThemeSetupCommand.php
@@ -131,7 +131,7 @@ EOT
                 $tenantRepository = $this->getContainer()->get('swp_multi_tenancy.tenant_repository');
                 $defaultTenant = $tenantRepository->findDefaultTenant();
                 if (null === $defaultTenant) {
-                    throw new \Exception("No default tenant found, please first run php app/console swp:tenant:create --default");
+                    throw new \Exception('No default tenant found, please first run php app/console swp:tenant:create --default');
                 }
 
                 if (null === $defaultTenant->getThemeName()) {

--- a/src/SWP/Bundle/MultiTenancyBundle/Command/CreateTenantCommand.php
+++ b/src/SWP/Bundle/MultiTenancyBundle/Command/CreateTenantCommand.php
@@ -14,6 +14,7 @@
 namespace SWP\Bundle\MultiTenancyBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
+use SWP\Bundle\MultiTenancyBundle\Repository\TenantRepository;
 use SWP\Component\MultiTenancy\Model\Tenant;
 use SWP\Component\MultiTenancy\Model\TenantInterface;
 use SWP\Component\MultiTenancy\Repository\TenantRepositoryInterface;
@@ -65,8 +66,8 @@ EOT
         $disabled = $input->getOption('disabled');
 
         if ($default) {
-            $subdomain = 'default';
-            $name = 'Default tenant';
+            $subdomain = TenantRepository::DEFAULT_TENANT_SUBDOMAIN;
+            $name = TenantRepository::DEFAULT_TENANT_NAME;
         }
 
         $tenant = $this->getTenantRepository()->findBySubdomain($subdomain);

--- a/src/SWP/Bundle/MultiTenancyBundle/Command/CreateTenantCommand.php
+++ b/src/SWP/Bundle/MultiTenancyBundle/Command/CreateTenantCommand.php
@@ -14,8 +14,6 @@
 namespace SWP\Bundle\MultiTenancyBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
-use SWP\Bundle\MultiTenancyBundle\Repository\TenantRepository;
-use SWP\Component\MultiTenancy\Model\Tenant;
 use SWP\Component\MultiTenancy\Model\TenantInterface;
 use SWP\Component\MultiTenancy\Repository\TenantRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;

--- a/src/SWP/Bundle/MultiTenancyBundle/Command/CreateTenantCommand.php
+++ b/src/SWP/Bundle/MultiTenancyBundle/Command/CreateTenantCommand.php
@@ -66,8 +66,8 @@ EOT
         $disabled = $input->getOption('disabled');
 
         if ($default) {
-            $subdomain = TenantRepository::DEFAULT_TENANT_SUBDOMAIN;
-            $name = TenantRepository::DEFAULT_TENANT_NAME;
+            $subdomain = TenantInterface::DEFAULT_TENANT_SUBDOMAIN;
+            $name = TenantInterface::DEFAULT_TENANT_NAME;
         }
 
         $tenant = $this->getTenantRepository()->findBySubdomain($subdomain);

--- a/src/SWP/Bundle/MultiTenancyBundle/Repository/TenantRepository.php
+++ b/src/SWP/Bundle/MultiTenancyBundle/Repository/TenantRepository.php
@@ -21,9 +21,6 @@ use SWP\Component\MultiTenancy\Repository\TenantRepositoryInterface;
  */
 class TenantRepository extends EntityRepository implements TenantRepositoryInterface
 {
-    const DEFAULT_TENANT_NAME = 'Default tenant';
-    const DEFAULT_TENANT_SUBDOMAIN = 'default';
-
     /**
      * {@inheritdoc}
      */
@@ -48,10 +45,5 @@ class TenantRepository extends EntityRepository implements TenantRepositoryInter
             ->where('t.enabled = true')
             ->getQuery()
             ->getArrayResult();
-    }
-
-    public function findDefaultTenant()
-    {
-        return $this->findOneBy(['name' => self::DEFAULT_TENANT_NAME]);
     }
 }

--- a/src/SWP/Bundle/MultiTenancyBundle/Repository/TenantRepository.php
+++ b/src/SWP/Bundle/MultiTenancyBundle/Repository/TenantRepository.php
@@ -21,6 +21,9 @@ use SWP\Component\MultiTenancy\Repository\TenantRepositoryInterface;
  */
 class TenantRepository extends EntityRepository implements TenantRepositoryInterface
 {
+    const DEFAULT_TENANT_NAME = 'Default tenant';
+    const DEFAULT_TENANT_SUBDOMAIN = 'default';
+
     /**
      * {@inheritdoc}
      */
@@ -45,5 +48,10 @@ class TenantRepository extends EntityRepository implements TenantRepositoryInter
             ->where('t.enabled = true')
             ->getQuery()
             ->getArrayResult();
+    }
+
+    public function findDefaultTenant()
+    {
+        return $this->findOneBy(['name' => self::DEFAULT_TENANT_NAME]);
     }
 }

--- a/src/SWP/Component/MultiTenancy/Model/TenantInterface.php
+++ b/src/SWP/Component/MultiTenancy/Model/TenantInterface.php
@@ -22,6 +22,9 @@ use SWP\Component\Common\Model\TimestampableInterface;
  */
 interface TenantInterface extends TimestampableInterface, EnableableInterface, SoftDeletableInterface
 {
+    const DEFAULT_TENANT_NAME = 'Default tenant';
+    const DEFAULT_TENANT_SUBDOMAIN = 'default';
+
     /**
      * Gets the tenant identifier.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [yes]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | [no]
| Tests pass?   | [yes]
| Fixed tickets | [SWP-189]
| License       | AGPLv3

By default, the default theme is now assigned to the default tenant by the theme:setup command. If there is no default tenant, an exception will be thrown, and the user will be prompted to run the swp:tenant:create command.