### PR TITLE
Implemented twig extension for Strings library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,8 @@
         "league/pipeline": "^0.2.2",
         "jms/translation-bundle": "^1.2",
         "symfony-cmf/menu-bundle": "2.0.*",
-        "hoa/mime": "3.16.01.15"
+        "hoa/mime": "3.16.01.15",
+        "danielstjules/stringy": "~2.3"
     },
     "require-dev": {
         "sensio/generator-bundle": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "72ef9b1234869e69b0ab8b3cfce7914f",
-    "content-hash": "83e3b372efdd8530fac4820731603665",
+    "hash": "dc66367e7e80d81dc40aa44d21379db6",
+    "content-hash": "59576ab1c3901975d8d22479a8de019d",
     "packages": [
         {
             "name": "ahilles107/updater",
@@ -168,6 +168,62 @@
                 "transliterator"
             ],
             "time": "2015-09-28 16:26:35"
+        },
+        {
+            "name": "danielstjules/stringy",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/danielstjules/Stringy.git",
+                "reference": "4e214a5195fae3fb558e81b1c6010678f7600643"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/danielstjules/Stringy/zipball/4e214a5195fae3fb558e81b1c6010678f7600643",
+                "reference": "4e214a5195fae3fb558e81b1c6010678f7600643",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/polyfill-mbstring": "~1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Stringy\\": "src/"
+                },
+                "files": [
+                    "src/Create.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel St. Jules",
+                    "email": "danielst.jules@gmail.com",
+                    "homepage": "http://www.danielstjules.com"
+                }
+            ],
+            "description": "A string manipulation library with multibyte support",
+            "homepage": "https://github.com/danielstjules/Stringy",
+            "keywords": [
+                "UTF",
+                "helpers",
+                "manipulation",
+                "methods",
+                "multibyte",
+                "string",
+                "utf-8",
+                "utility",
+                "utils"
+            ],
+            "time": "2016-05-02 15:18:10"
         },
         {
             "name": "doctrine/annotations",
@@ -1296,7 +1352,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSHttpCacheBundle/zipball/1009876f6b2b319d3d7f7e0e7bc8375890bddd9c",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSHttpCacheBundle/zipball/a798b287b8d06b49be5c4f05c3d3b6a200a8f0c3",
                 "reference": "1009876f6b2b319d3d7f7e0e7bc8375890bddd9c",
                 "shasum": ""
             },
@@ -1376,7 +1432,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSRestBundle/zipball/5bd68a76b2957eb009b1d7d95e9573b11e710d8b",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSRestBundle/zipball/5d0f28334970d2601c16c82bd4c6183df2f639a6",
                 "reference": "5bd68a76b2957eb009b1d7d95e9573b11e710d8b",
                 "shasum": ""
             },
@@ -1629,7 +1685,6 @@
                 "rest",
                 "web service"
             ],
-            "abandoned": "guzzlehttp/guzzle",
             "time": "2015-03-18 18:23:50"
         },
         {
@@ -4375,7 +4430,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SuperdeskWebPublisher/SWPUpdaterBundle/zipball/cd2c44a2b6a52240304eddc2f1bf0812cd255db4",
+                "url": "https://api.github.com/repos/SuperdeskWebPublisher/SWPUpdaterBundle/zipball/e1bb2169ca60d733ce5b0afcb684718cab47026a",
                 "reference": "cd2c44a2b6a52240304eddc2f1bf0812cd255db4",
                 "shasum": ""
             },
@@ -4675,7 +4730,7 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony CMF community",
+                    "name": "Symfony CMF Community",
                     "homepage": "https://github.com/symfony-cmf/Routing/contributors"
                 }
             ],
@@ -5441,7 +5496,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/6404e8e033980ad4d522f71e0c3278d4e53d22b8",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/4009b5e54d3253e1461c9119f56f768e4f8528ab",
                 "reference": "6404e8e033980ad4d522f71e0c3278d4e53d22b8",
                 "shasum": ""
             },

--- a/docs/templates_system/templates.rst
+++ b/docs/templates_system/templates.rst
@@ -138,3 +138,30 @@ Here's an example using gimmelist:
     {% gimmelist article from articles %}
         <li><a href="{{ url(article) }}">{{ article.title }} </a></li>
     {% endgimmelist %}
+
+
+Stringy twig extensions
+-----------------------
+
+We have extended the twig syntax, adding a number of functions for working with strings from a php library. A list of the functions together with a description of each, and of how they are to be invoked in PHP can be found here: https://github.com/danielstjules/Stringy#instance-methods
+
+To call one of these functions in twig, if it returns a boolean, it is available as a twig function. So, for example, the function contains() can be called like this in twig:
+
+.. code-block:: twig
+
+    {% set string_var = 'contains' %}
+    {% if contains(string_var, 'tain') %}string_var{% endif %} // will render contains
+
+Any php function which returns a string is available in twig as a filter. So, for example, the function between() can be called like this in twig:
+
+.. code-block:: twig
+
+    {% set string_var = 'Beginning' %}
+    {{ string_var|between('Be', 'ning') }} // will render gin
+
+And the function camelize(), which doesn't require any parameters, can simply be called like this:
+
+.. code-block:: twig
+
+    {% set string_var = 'Beginning' %}
+    {{ string_var|camelize }} // will render bEGINNING

--- a/src/SWP/Bundle/TemplateEngineBundle/Controller/ContainerController.php
+++ b/src/SWP/Bundle/TemplateEngineBundle/Controller/ContainerController.php
@@ -19,6 +19,7 @@ use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Stringy\StaticStringy;
 use SWP\Bundle\TemplateEngineBundle\Form\Type\ContainerType;
 use SWP\Bundle\TemplateEngineBundle\Model\ContainerData;
 use SWP\Bundle\TemplateEngineBundle\Model\ContainerWidget;

--- a/src/SWP/Bundle/TemplateEngineBundle/Controller/ContainerController.php
+++ b/src/SWP/Bundle/TemplateEngineBundle/Controller/ContainerController.php
@@ -19,7 +19,6 @@ use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Stringy\StaticStringy;
 use SWP\Bundle\TemplateEngineBundle\Form\Type\ContainerType;
 use SWP\Bundle\TemplateEngineBundle\Model\ContainerData;
 use SWP\Bundle\TemplateEngineBundle\Model\ContainerWidget;

--- a/src/SWP/Bundle/TemplateEngineBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/TemplateEngineBundle/Resources/config/services.yml
@@ -68,4 +68,3 @@ services:
             - "%swp_multi_tenancy.persistence.phpcr.menu_basepath%"
         tags:
             - { name: knp_menu.provider }
-

--- a/src/SWP/Bundle/WebRendererBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/WebRendererBundle/Resources/config/services.yml
@@ -58,3 +58,11 @@ services:
             - "@swp_template_engine_loader_chain"
         tags:
             -  { name: dynamic_router_route_enhancer, priority: 10 }
+
+    swp_webrenderer.twig_stringy_extension:
+        class: SWP\Bundle\WebRendererBundle\Twig\StringyExtension
+        public: false
+        arguments:
+            - "@twig"
+        tags:
+            - {name: twig.extension}

--- a/src/SWP/Bundle/WebRendererBundle/Tests/Twig/StringyExtensionTest.php
+++ b/src/SWP/Bundle/WebRendererBundle/Tests/Twig/StringyExtensionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the Superdesk Web Publisher Web Renderer Bundle.
+ *
+ * Copyright 2016 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2016 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+namespace SWP\Bundle\WebRendererBundle\Tests\Twig;
+
+
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+
+class StringyExtensionTest extends WebTestCase
+{
+    /**
+     * @var \Twig_Environment
+     */
+    private $twig;
+
+    public function setUp()
+    {
+        self::bootKernel();
+
+        $this->twig = $this->getContainer()->get('Twig');
+    }
+
+    public function testCamelize()
+    {
+        $this->assertEquals($this->getRendered('{{ value|camelize }}', ['value' => 'AROOGA']), 'aROOGA');
+    }
+
+    public function testBetween()
+    {
+        $this->assertEquals($this->getRendered("{{ value|between('AR', 'GA') }}", ['value' => 'AROOGA']), 'OO');
+    }
+
+    public function testCollapseWhiteSpace()
+    {
+        $this->assertEquals($this->getRendered("{{ value|collapseWhitespace }}", ['value' => 'AR      OO     GA']), 'AR OO GA');
+    }
+
+    public function testContains()
+    {
+        $this->assertEquals($this->getRendered("{% if hasUpperCase(value) %}AROOGA{% endif %}", ['value' => 'AROOGA']), 'AROOGA');
+    }
+
+    private function getRendered($template, $context=[])
+    {
+        $template = $this->twig->createTemplate($template);
+        $content = $template->render($context);
+
+        return $content;
+    }
+}

--- a/src/SWP/Bundle/WebRendererBundle/Tests/Twig/StringyExtensionTest.php
+++ b/src/SWP/Bundle/WebRendererBundle/Tests/Twig/StringyExtensionTest.php
@@ -13,7 +13,6 @@
  */
 namespace SWP\Bundle\WebRendererBundle\Tests\Twig;
 
-
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 
 class StringyExtensionTest extends WebTestCase

--- a/src/SWP/Bundle/WebRendererBundle/Tests/Twig/StringyExtensionTest.php
+++ b/src/SWP/Bundle/WebRendererBundle/Tests/Twig/StringyExtensionTest.php
@@ -42,15 +42,15 @@ class StringyExtensionTest extends WebTestCase
 
     public function testCollapseWhiteSpace()
     {
-        $this->assertEquals($this->getRendered("{{ value|collapseWhitespace }}", ['value' => 'AR      OO     GA']), 'AR OO GA');
+        $this->assertEquals($this->getRendered('{{ value|collapseWhitespace }}', ['value' => 'AR      OO     GA']), 'AR OO GA');
     }
 
     public function testContains()
     {
-        $this->assertEquals($this->getRendered("{% if hasUpperCase(value) %}AROOGA{% endif %}", ['value' => 'AROOGA']), 'AROOGA');
+        $this->assertEquals($this->getRendered('{% if hasUpperCase(value) %}AROOGA{% endif %}', ['value' => 'AROOGA']), 'AROOGA');
     }
 
-    private function getRendered($template, $context=[])
+    private function getRendered($template, $context = [])
     {
         $template = $this->twig->createTemplate($template);
         $content = $template->render($context);

--- a/src/SWP/Bundle/WebRendererBundle/Tests/Twig/StringyExtensionTest.php
+++ b/src/SWP/Bundle/WebRendererBundle/Tests/Twig/StringyExtensionTest.php
@@ -44,9 +44,14 @@ class StringyExtensionTest extends WebTestCase
         $this->assertEquals($this->getRendered('{{ value|collapseWhitespace }}', ['value' => 'AR      OO     GA']), 'AR OO GA');
     }
 
-    public function testContains()
+    public function testUpperCase()
     {
         $this->assertEquals($this->getRendered('{% if hasUpperCase(value) %}AROOGA{% endif %}', ['value' => 'AROOGA']), 'AROOGA');
+    }
+
+    public function testContains()
+    {
+        $this->assertEquals($this->getRendered("{% if contains(value, 'OOG') %}AROOGA{% endif %}", ['value' => 'AROOGA']), 'AROOGA');
     }
 
     private function getRendered($template, $context = [])

--- a/src/SWP/Bundle/WebRendererBundle/Twig/StringyExtension.php
+++ b/src/SWP/Bundle/WebRendererBundle/Twig/StringyExtension.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of the Superdesk Web Publisher Template Engine Bundle.
+ *
+ * Copyright 2016 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2016 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+namespace SWP\Bundle\WebRendererBundle\Twig;
+
+class StringyExtension extends \Twig_Extension
+{
+    const EXCLUDE_FUNCTIONS = ['__construct', '__toString', 'create'];
+
+    protected $environment;
+
+    protected $functions = [];
+
+    protected $filters = [];
+
+    public function __construct(\Twig_Environment $environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFilters()
+    {
+        $this->lazyInit();
+
+        return $this->filters;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFunctions()
+    {
+        $this->lazyInit();
+
+        return $this->functions;
+    }
+
+    /**
+     * Initializes arrays of filters and functions
+     */
+    private function lazyInit()
+    {
+        $stringyClass = new \ReflectionClass('Stringy\Stringy');
+        $methods = $stringyClass->getMethods(\ReflectionMethod::IS_PUBLIC);
+        $names = array_map(function($value){
+            return $value->getName();
+        }, $methods);
+
+        foreach ($names as $name) {
+            if (in_array($name, self::EXCLUDE_FUNCTIONS)) {
+                continue;
+            }
+
+            if ($this->environment->getFilter($name)) {
+                continue;
+            }
+
+            $method = $stringyClass->getMethod($name);
+            $doc = $method->getDocComment();
+            if (strpos($doc, '@return bool')) {
+                $this->functions[$name] = new \Twig_SimpleFunction($name, array('Stringy\StaticStringy', $name));
+            }
+
+            else {
+                $this->filters[$name] = new \Twig_SimpleFilter($name, array('Stringy\StaticStringy', $name));
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getName()
+    {
+        return 'stringy_extension';
+    }
+}

--- a/src/SWP/Bundle/WebRendererBundle/Twig/StringyExtension.php
+++ b/src/SWP/Bundle/WebRendererBundle/Twig/StringyExtension.php
@@ -29,7 +29,7 @@ class StringyExtension extends \Twig_Extension
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getFilters()
     {
@@ -39,7 +39,7 @@ class StringyExtension extends \Twig_Extension
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getFunctions()
     {
@@ -49,13 +49,13 @@ class StringyExtension extends \Twig_Extension
     }
 
     /**
-     * Initializes arrays of filters and functions
+     * Initializes arrays of filters and functions.
      */
     private function lazyInit()
     {
         $stringyClass = new \ReflectionClass('Stringy\Stringy');
         $methods = $stringyClass->getMethods(\ReflectionMethod::IS_PUBLIC);
-        $names = array_map(function($value){
+        $names = array_map(function ($value) {
             return $value->getName();
         }, $methods);
 
@@ -72,16 +72,14 @@ class StringyExtension extends \Twig_Extension
             $doc = $method->getDocComment();
             if (strpos($doc, '@return bool')) {
                 $this->functions[$name] = new \Twig_SimpleFunction($name, array('Stringy\StaticStringy', $name));
-            }
-
-            else {
+            } else {
                 $this->filters[$name] = new \Twig_SimpleFilter($name, array('Stringy\StaticStringy', $name));
             }
         }
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getName()
     {

--- a/src/SWP/Bundle/WebRendererBundle/Twig/StringyExtension.php
+++ b/src/SWP/Bundle/WebRendererBundle/Twig/StringyExtension.php
@@ -17,10 +17,19 @@ class StringyExtension extends \Twig_Extension
 {
     const EXCLUDE_FUNCTIONS = ['__construct', '__toString', 'create'];
 
+    /**
+     * @var \Twig_Environment
+     */
     protected $environment;
 
+    /**
+     * @var array
+     */
     protected $functions = [];
 
+    /**
+     * @var array
+     */
     protected $filters = [];
 
     public function __construct(\Twig_Environment $environment)
@@ -64,16 +73,22 @@ class StringyExtension extends \Twig_Extension
                 continue;
             }
 
-            if ($this->environment->getFilter($name)) {
-                continue;
-            }
-
             $method = $stringyClass->getMethod($name);
+
+            // Get the return type from the doc comment
             $doc = $method->getDocComment();
             if (strpos($doc, '@return bool')) {
-                $this->functions[$name] = new \Twig_SimpleFunction($name, array('Stringy\StaticStringy', $name));
+                // Don't add functions which have the same name as any already in the environment
+                if ($this->environment->getFunction($name)) {
+                    continue;
+                }
+                $this->functions[$name] = new \Twig_SimpleFunction($name, ['Stringy\StaticStringy', $name]);
             } else {
-                $this->filters[$name] = new \Twig_SimpleFilter($name, array('Stringy\StaticStringy', $name));
+                // Don't add filters which have the same name as any already in the environment
+                if ($this->environment->getFilter($name)) {
+                    continue;
+                }
+                $this->filters[$name] = new \Twig_SimpleFilter($name, ['Stringy\StaticStringy', $name]);
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [yes]
| New feature?  | [yes]
| BC breaks?    | [no]
| Deprecations? | [no]
| Tests pass?   | [yes]
| Fixed tickets | [SWP-235]
| License       | AGPLv3

All functions in this Stringy library (https://github.com/danielstjules/Stringy) have been made available in twig. Functions which manipulate strings are available as filters, while functions which return booleans are available as functions. So, {{ value|camelize }} will render the value in camel case, while {% if hasUpperCase(value) %} will be true if the value has any upper case character.