### PR TITLE
Article loader fix

### DIFF
--- a/src/SWP/Bundle/ContentBundle/Loader/ArticleLoader.php
+++ b/src/SWP/Bundle/ContentBundle/Loader/ArticleLoader.php
@@ -129,7 +129,11 @@ class ArticleLoader implements LoaderInterface
                         if ($order[0] === 'id') {
                             $order[0] = 'jcr:uuid';
                         } else {
-                            $order[0] = mysqli_real_escape_string($order[0]);
+                            // Check that the given parameter is actually a field name of a route
+                            $metaData = $this->dm->getClassMetadata('SWP\Bundle\ContentBundle\Doctrine\ODM\PHPCR\Article');
+                            if (!in_array($order[0], $metaData->getFieldNames())) {
+                                throw new \Exception('Order parameter must be id or the name of one of the fields in the route class');
+                            }
                         }
                         $queryStr .= sprintf(' ORDER BY S.%s %s', $order[0], $order[1]);
                     }

--- a/src/SWP/Bundle/ContentBundle/Tests/Loader/ArticleLoaderTest.php
+++ b/src/SWP/Bundle/ContentBundle/Tests/Loader/ArticleLoaderTest.php
@@ -74,13 +74,25 @@ class ArticleLoaderTest extends WebTestCase
 
         $this->assertTrue($articlesZero[1]->title === $articlesOne[0]->title);
 
-        $articlesAsc = $this->articleLoader->load('article', ['route' => '/news', 'order' => ['id', 'asc']], LoaderInterface::COLLECTION);
-        $articlesDesc = $this->articleLoader->load('article', ['route' => '/news', 'order' => ['id', 'desc']], LoaderInterface::COLLECTION);
+        $articlesAsc = $this->articleLoader->load('article', ['route' => '/news', 'order' => ['title', 'asc']], LoaderInterface::COLLECTION);
+        $articlesDesc = $this->articleLoader->load('article', ['route' => '/news', 'order' => ['title', 'desc']], LoaderInterface::COLLECTION);
 
         $this->assertTrue(count($articlesAsc) == count($articlesDesc));
 
         $count = count($articlesAsc);
         $this->assertTrue($articlesAsc[0]->title === $articlesDesc[$count - 1]->title);
         $this->assertTrue($articlesAsc[$count - 1]->title === $articlesDesc[0]->title);
+    }
+
+    public function testLoadWithOrderByIdParameter()
+    {
+        $this->assertEquals(3, count($this->articleLoader->load('article', ['route' => '/news', 'order' => ['id', 'asc']], LoaderInterface::COLLECTION)));
+    }
+
+    public function testLoadWithInvalidOrderByParameter()
+    {
+        $this->expectException(\Exception::class);
+
+        $this->articleLoader->load('article', ['route' => '/news', 'order' => ['truncate Table', 'asc']], LoaderInterface::COLLECTION);
     }
 }


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | [yes]
| New feature?              | [no]
| BC breaks?                | [no]
| Deprecations?             | [no]
| Tests pass?               | [yes]
| Changelog update required | [no]
| Fixed tickets             | [SWP-270]
| License                   | AGPLv3

Fixes use of 'order by' with a parameter other than id when loading articles in a template
