### PR TITLE
Revert HttpCacheSubscriber

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -180,7 +180,7 @@ fos_http_cache:
             -
                 match:
                     attributes:
-                        _route: "swp_api_templates_update_container|swp_api_templates_delete_container"
+                        _route: "swp_api_templates_update_container|swp_api_templates_delete_container|swp_api_templates_link_container"
                 routes:
                     swp_api_templates_list_containers: ~
                     swp_api_templates_get_container: ~

--- a/src/SWP/Bundle/CoreBundle/EventSubscriber/HttpCacheSubscriber.php
+++ b/src/SWP/Bundle/CoreBundle/EventSubscriber/HttpCacheSubscriber.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Superdesk Web Publisher Template Engine Bundle.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\EventSubscriber;
+
+use FOS\HttpCache\Exception\ExceptionCollection;
+use FOS\HttpCacheBundle\CacheManager;
+use Psr\Log\LoggerInterface;
+use SWP\Component\Common\Event\HttpCacheEvent;
+use SWP\Component\TemplatesSystem\Gimme\Model\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class HttpCacheSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var CacheManager
+     */
+    protected $cacheManager;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    public function __construct(CacheManager $cacheManager, LoggerInterface $logger)
+    {
+        $this->cacheManager = $cacheManager;
+        $this->logger = $logger;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            HttpCacheEvent::EVENT_NAME => [
+                ['clearCache', 0],
+            ],
+        ];
+    }
+
+    public function clearCache(HttpCacheEvent $event)
+    {
+        switch (true) {
+            case $event->getSubject() instanceof ContainerInterface:
+                $this->cacheManager->invalidateRoute('swp_api_templates_list_containers');
+                $this->cacheManager->invalidateRoute('swp_api_templates_get_container', [
+                    'id' => $event->getSubject()->getId(),
+                ]);
+                break;
+        }
+
+        try {
+            $this->cacheManager->flush();
+        } catch (ExceptionCollection $e) {
+            $this->logger->error($e->getMessage());
+        }
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -93,3 +93,11 @@ services:
         class: SWP\Bundle\CoreBundle\Security\Storage\DynamicDomainSessionStorage
         arguments:
             - "%domain%"
+
+    swp_core.subscriber.http_cache:
+        class: SWP\Bundle\CoreBundle\EventSubscriber\HttpCacheSubscriber
+        arguments:
+            - "@fos_http_cache.cache_manager"
+            - "@logger"
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/SWP/Component/Common/Event/HttpCacheEvent.php
+++ b/src/SWP/Component/Common/Event/HttpCacheEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Superdesk Web Publisher Common Component.
+ *
+ * Copyright 2015 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2015 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Component\Common\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class HttpCacheEvent extends Event
+{
+    /**
+     * Event name.
+     */
+    const EVENT_NAME = 'swp_http_cache.clear';
+
+    protected $subject;
+
+    public function __construct($subject)
+    {
+        $this->subject = $subject;
+    }
+
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+}


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | no
| New feature?              | no
| BC breaks?                | yes
| Deprecations?             | no
| Tests pass?               | yes
| License                   | AGPLv3

Revert HttpCache subscriber so we can manual control on http cache invalidation. For example we use it now in Containers.