### PR TITLE
make article media tenant aware

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Model/ArticleMedia.php
+++ b/src/SWP/Bundle/CoreBundle/Model/ArticleMedia.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Model;
+
+use SWP\Bundle\ContentBundle\Model\ArticleMedia as BaseArticleMedia;
+use SWP\Component\MultiTenancy\Model\TenantAwareTrait;
+
+class ArticleMedia extends BaseArticleMedia implements ArticleMediaInterface
+{
+    use TenantAwareTrait;
+}

--- a/src/SWP/Bundle/CoreBundle/Model/ArticleMediaInterface.php
+++ b/src/SWP/Bundle/CoreBundle/Model/ArticleMediaInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Model;
+
+use SWP\Component\MultiTenancy\Model\TenantAwareInterface;
+
+interface ArticleMediaInterface extends TenantAwareInterface
+{
+}

--- a/src/SWP/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -80,6 +80,8 @@ swp_content:
             classes:
                 article:
                     model: SWP\Bundle\CoreBundle\Model\Article
+                media:
+                    model: SWP\Bundle\CoreBundle\Model\ArticleMedia
                 route:
                     model: SWP\Bundle\CoreBundle\Model\Route
 

--- a/src/SWP/Bundle/CoreBundle/Resources/config/doctrine-orm/ArticleMedia.orm.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/doctrine-orm/ArticleMedia.orm.yml
@@ -1,0 +1,6 @@
+SWP\Bundle\CoreBundle\Model\ArticleMedia:
+    type: mappedSuperclass
+    table: swp_article_media
+    fields:
+        tenantCode:
+            type: string

--- a/src/SWP/Bundle/CoreBundle/spec/Model/ArticleMediaSpec.php
+++ b/src/SWP/Bundle/CoreBundle/spec/Model/ArticleMediaSpec.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú.
+ * @license http://www.superdesk.org/license
+ */
+
+namespace spec\SWP\Bundle\CoreBundle\Model;
+
+use SWP\Bundle\CoreBundle\Model\ArticleMedia;
+use SWP\Bundle\ContentBundle\Model\ArticleMedia as BaseArticleMedia;
+use PhpSpec\ObjectBehavior;
+use SWP\Bundle\CoreBundle\Model\ArticleMediaInterface;
+
+final class ArticleMediaSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ArticleMedia::class);
+    }
+
+    function it_implements_interface()
+    {
+        $this->shouldImplement(ArticleMediaInterface::class);
+    }
+
+    function it_extends_article_media()
+    {
+        $this->shouldHaveType(BaseArticleMedia::class);
+    }
+
+    function it_has_no_tenant_code_by_default()
+    {
+        $this->getTenantCode()->shouldReturn(null);
+    }
+
+    function its_tenant_code_is_mutable()
+    {
+        $this->setTenantCode('12345');
+        $this->getTenantCode()->shouldReturn('12345');
+    }
+}


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | yes
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | no
| License                   | AGPLv3


Article media should be tenant aware, it means that every tenant should have its own media for every article.