### PR TITLE
Content is not automatically assigned to route of type 'content'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ in 0.1 minor versions.
 To get the diff for a specific change, go to https://github.com/superdesk/web-publisher/commit/XXX where XXX is the change hash
 
 * 0.2.0
+ * feature [#218] Assign article to route of type content automatically when article is published
  * feature [#215] Filter articles by metadata in gimmelist
  * feature [#213] Implement and expose article's keywords
  * feature [#211] Create Automatic list widget

--- a/src/SWP/Bundle/ContentBundle/Rule/Applicator/ArticleRuleApplicator.php
+++ b/src/SWP/Bundle/ContentBundle/Rule/Applicator/ArticleRuleApplicator.php
@@ -16,6 +16,7 @@ namespace SWP\Bundle\ContentBundle\Rule\Applicator;
 
 use Psr\Log\LoggerInterface;
 use SWP\Bundle\ContentBundle\Model\ArticleInterface;
+use SWP\Bundle\ContentBundle\Model\RouteInterface;
 use SWP\Bundle\ContentBundle\Provider\RouteProviderInterface;
 use SWP\Bundle\ContentBundle\Service\ArticleServiceInterface;
 use SWP\Component\Rule\Applicator\RuleApplicatorInterface;
@@ -84,6 +85,10 @@ final class ArticleRuleApplicator implements RuleApplicatorInterface
             }
 
             $subject->setRoute($route);
+
+            if (RouteInterface::TYPE_CONTENT === $route->getType()) {
+                $route->setContent($subject);
+            }
         }
 
         $subject->setTemplateName($configuration['templateName']);

--- a/src/SWP/Bundle/ContentBundle/spec/Rule/Applicator/ArticleRuleApplicatorSpec.php
+++ b/src/SWP/Bundle/ContentBundle/spec/Rule/Applicator/ArticleRuleApplicatorSpec.php
@@ -123,4 +123,30 @@ final class ArticleRuleApplicatorSpec extends ObjectBehavior
 
         $this->apply($rule, $subject)->shouldReturn(null);
     }
+
+    public function it_applies_rule_and_assigns_content_to_route(
+        RuleInterface $rule,
+        Article $subject,
+        RouteProviderInterface $routeProvider,
+        RouteInterface $route,
+        LoggerInterface $logger,
+        ArticleServiceInterface $articleService
+    ) {
+        $rule->getConfiguration()->willReturn([
+            'route' => 'some/route',
+            'templateName' => 'template.twig.html',
+            'published' => 'true',
+        ]);
+        $rule->getExpression()->willReturn('article.getSomething("something") matches /something/');
+        $route->getType()->willReturn(RouteInterface::TYPE_CONTENT);
+        $routeProvider->getOneById('some/route')->willReturn($route);
+
+        $subject->setRoute($route)->shouldBeCalled();
+        $route->setContent($subject)->shouldBeCalled();
+        $subject->setTemplateName('template.twig.html')->shouldBeCalled();
+        $articleService->publish($subject)->shouldBeCalled();
+        $logger->info(Argument::any('string'))->shouldBeCalled();
+
+        $this->apply($rule, $subject)->shouldReturn(null);
+    }
 }

--- a/src/SWP/Bundle/CoreBundle/Tests/Controller/ArticleAutoPublishTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Controller/ArticleAutoPublishTest.php
@@ -14,6 +14,7 @@
 
 namespace SWP\Bundle\CoreBundle\Tests\Controller;
 
+use SWP\Bundle\ContentBundle\Model\RouteInterface;
 use SWP\Bundle\FixturesBundle\WebTestCase;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -116,6 +117,72 @@ class ArticleAutoPublishTest extends WebTestCase
         self::assertEquals($content['status'], 'new');
     }
 
+    public function testAssignRouteContentWhenArticleIsPublished()
+    {
+        $client = static::createClient();
+
+        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
+            'route' => [
+                'name' => 'article',
+                'type' => RouteInterface::TYPE_CONTENT,
+            ],
+        ]);
+
+        self::assertEquals(201, $client->getResponse()->getStatusCode());
+
+        $route = json_decode($client->getResponse()->getContent(), true);
+
+        $client->request('POST', $this->router->generate('swp_api_core_create_rule'), [
+            'rule' => [
+                'expression' => 'article.getMetadataByKey("located") matches "/Sydney/"',
+                'priority' => 1,
+                'configuration' => [
+                    [
+                        'key' => 'published',
+                        'value' => true,
+                    ],
+                    [
+                        'key' => 'route',
+                        'value' => $route['id'],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertEquals(201, $client->getResponse()->getStatusCode());
+
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_push'),
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            self::TEST_ITEM_CONTENT
+        );
+
+        self::assertEquals(201, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', $this->router->generate('swp_api_content_show_routes', [
+            'id' => $route['id'],
+        ]));
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $content = json_decode($client->getResponse()->getContent(), true);
+
+        $client->request(
+            'GET',
+            $this->router->generate('swp_api_content_show_articles', ['id' => 'abstract-html-test'])
+        );
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $article = json_decode($client->getResponse()->getContent(), true);
+
+        self::assertArrayHasKey('content', $content);
+        self::assertEquals($content['content']['id'], $article['id']);
+    }
+
     private function createRouteAndPushContent()
     {
         $client = static::createClient();
@@ -123,7 +190,7 @@ class ArticleAutoPublishTest extends WebTestCase
         $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
             'route' => [
                 'name' => 'articles',
-                'type' => 'collection',
+                'type' => RouteInterface::TYPE_COLLECTION,
                 'content' => null,
             ],
         ]);


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | no
| New feature?              | yes
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | yes
| Fixed tickets             | SWP-561
| License                   | AGPLv3


Before it was possible to do it but only manually via API for routes. Right now article will be assigned to route (of type `content`) automatically once the article will be published