### PR TITLE
Automatically create menu widget when root menu/navigation is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ in 0.1 minor versions.
 To get the diff for a specific change, go to https://github.com/superdesk/web-publisher/commit/XXX where XXX is the change hash
 
 * 0.2.0
+ * feature [#219] Automatically create menu widget when root menu/navigation is created
  * feature [#218] Assign article to route of type content automatically when article is published
  * feature [#215] Filter articles by metadata in gimmelist
  * feature [#213] Implement and expose article's keywords

--- a/docs/cookbooks/developers/content_lists.rst
+++ b/docs/cookbooks/developers/content_lists.rst
@@ -35,11 +35,16 @@ is assigned to "Sports" route, it will be automatically assigned to the list.
 Built in criteria:
 
 - ``route`` - an array of route ids, e.g. [1,5]
+
 - ``author`` - an array of authors, e.g. ["Test Persona","Doe"]
+
 - ``publishedBefore`` - date string, articles published before this date will be added to the list,
 e.g. dates: "2017-01-05" or "05-01-2017" etc. (date format doesn't matter)
+
 - ``publishedAfter`` - date string, articles published after that date will be added to the list, format is the same as in the ``publishedBefore`` case.
+
 - ``publishedAt`` - date string, when defined articles matching this publish dates will be added to the list when published, format is the same as in case of ``publishedBefore`` and ``publishedAfter``
+
 - ``metadata`` - metadata field is json string, e.g. ``{"metadata":{"language":"en"}}``. It matches article's metadata, and you can use all metadata fields that are defined for the article, i.e.: language, located etc.
 
 All criteria can be combined together which in the result it will add articles to the list (on publish) depending on your needs.

--- a/docs/cookbooks/editors/adding_menu.rst
+++ b/docs/cookbooks/editors/adding_menu.rst
@@ -3,7 +3,7 @@ Adding new menus
 
 Adding new menu and its items is very easy. Once the menu is created the menu widget will be automatically created so you can use it instantly without a need to create it manually.
 
-Newly created menu widget will be, by default, use ``menu.html.twig`` template and will point to the menu you created.
+Newly created menu widget will, by default, use ``menu.html.twig`` template and will point to the menu you created.
 
 Here is an example to demonstrate this:
 

--- a/docs/cookbooks/editors/adding_menu.rst
+++ b/docs/cookbooks/editors/adding_menu.rst
@@ -1,0 +1,14 @@
+Adding new menus
+================
+
+Adding new menu and its items is very easy. Once the menu is created the menu widget will be automatically created so you can use it instantly without a need to create it manually.
+
+Newly created menu widget will be, by default, use ``menu.html.twig`` template and will point to the menu you created.
+
+Here is an example to demonstrate this:
+
+Once the new menu with name ``Sports`` is created, menu widget will be automatically created with a name: ``Sports`` and template: ``menu.html.twig``. New menu widget, by default, will point to newly created menu (with name ``Sports``). When this menu widget will be used in template, the menu assigned to that widget will be automatically rendered i.e. the ``Sports`` menu.
+
+.. note::
+
+  Menu widget will be created automatically for you only for the main menus (root menus), not for the menu items.

--- a/docs/cookbooks/editors/index.rst
+++ b/docs/cookbooks/editors/index.rst
@@ -3,3 +3,4 @@ Editors Cookbooks
 .. toctree::
 
     configure_facebook_instant_articles
+    adding_menu

--- a/src/SWP/Bundle/CoreBundle/EventListener/MenuWidgetCreateListener.php
+++ b/src/SWP/Bundle/CoreBundle/EventListener/MenuWidgetCreateListener.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\EventListener;
+
+use SWP\Bundle\MenuBundle\Model\MenuItemInterface;
+use SWP\Component\Common\Exception\UnexpectedTypeException;
+use SWP\Component\Storage\Factory\FactoryInterface;
+use SWP\Component\Storage\Repository\RepositoryInterface;
+use SWP\Component\TemplatesSystem\Gimme\Model\WidgetModelInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class MenuWidgetCreateListener
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $widgetFactory;
+
+    /**
+     * @var RepositoryInterface
+     */
+    private $widgetRepository;
+
+    /**
+     * @param FactoryInterface    $widgetFactory
+     * @param RepositoryInterface $widgetRepository
+     */
+    public function __construct(
+        FactoryInterface $widgetFactory,
+        RepositoryInterface $widgetRepository
+    ) {
+        $this->widgetFactory = $widgetFactory;
+        $this->widgetRepository = $widgetRepository;
+    }
+
+    /**
+     * @param GenericEvent $event
+     */
+    public function onMenuCreated(GenericEvent $event)
+    {
+        /** @var MenuItemInterface $subject */
+        if (!($subject = $event->getSubject()) instanceof MenuItemInterface) {
+            throw UnexpectedTypeException::unexpectedType(get_class($subject), MenuItemInterface::class);
+        }
+
+        if (null !== $subject->getParent()) {
+            return;
+        }
+
+        /** @var WidgetModelInterface $widget */
+        $widget = $this->widgetFactory->create();
+        $widget->setType(WidgetModelInterface::TYPE_MENU);
+        $widget->setName($subject->getName());
+        $widget->setParameters([
+            'menu_name' => $subject->getName(),
+        ]);
+
+        $this->widgetRepository->add($widget);
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/EventListener/MenuWidgetDeleteListener.php
+++ b/src/SWP/Bundle/CoreBundle/EventListener/MenuWidgetDeleteListener.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\EventListener;
+
+use SWP\Bundle\MenuBundle\Model\MenuItemInterface;
+use SWP\Component\Common\Exception\UnexpectedTypeException;
+use SWP\Component\Storage\Repository\RepositoryInterface;
+use SWP\Component\TemplatesSystem\Gimme\Model\WidgetModelInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class MenuWidgetDeleteListener
+{
+    /**
+     * @var RepositoryInterface
+     */
+    private $widgetRepository;
+
+    /**
+     * @param RepositoryInterface $widgetRepository
+     */
+    public function __construct(RepositoryInterface $widgetRepository)
+    {
+        $this->widgetRepository = $widgetRepository;
+    }
+
+    /**
+     * @param GenericEvent $event
+     */
+    public function onMenuDeleted(GenericEvent $event)
+    {
+        /** @var MenuItemInterface $subject */
+        if (!($subject = $event->getSubject()) instanceof MenuItemInterface) {
+            throw UnexpectedTypeException::unexpectedType(get_class($subject), MenuItemInterface::class);
+        }
+
+        if (null !== $subject->getParent()) {
+            return;
+        }
+
+        /** @var WidgetModelInterface $widget */
+        $widget = $this->widgetRepository->findOneBy(['name' => $subject->getName()]);
+
+        if (null !== $widget) {
+            $this->widgetRepository->remove($widget);
+        }
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -180,3 +180,11 @@ services:
             - '@swp.factory.content_list_item'
         tags:
             - { name: kernel.event_listener, event: swp.list_criteria_change, method: onListCriteriaChange }
+
+    swp.listener.menu.widget_create:
+        class: SWP\Bundle\CoreBundle\EventListener\MenuWidgetCreateListener
+        arguments:
+            - '@swp.factory.widget_model'
+            - '@swp.repository.widget_model'
+        tags:
+            - { name: kernel.event_listener, event: swp.menu.created, method: onMenuCreated }

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -188,3 +188,10 @@ services:
             - '@swp.repository.widget_model'
         tags:
             - { name: kernel.event_listener, event: swp.menu.created, method: onMenuCreated }
+
+    swp.listener.menu.widget_delete:
+        class: SWP\Bundle\CoreBundle\EventListener\MenuWidgetDeleteListener
+        arguments:
+            - '@swp.repository.widget_model'
+        tags:
+            - { name: kernel.event_listener, event: swp.menu.deleted, method: onMenuDeleted }

--- a/src/SWP/Bundle/CoreBundle/Tests/Controller/MenuControllerTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Controller/MenuControllerTest.php
@@ -38,6 +38,9 @@ class MenuControllerTest extends WebTestCase
     public function testCreateMenuApi()
     {
         $client = static::createClient();
+        $client->request('GET', $this->router->generate('swp_api_templates_get_widget', ['id' => 1]));
+        self::assertEquals(404, $client->getResponse()->getStatusCode());
+
         $client->request('POST', $this->router->generate('swp_api_core_create_menu'), [
             'menu' => [
                 'name' => 'main-menu',
@@ -47,8 +50,14 @@ class MenuControllerTest extends WebTestCase
 
         self::assertEquals(201, $client->getResponse()->getStatusCode());
         $content = $client->getResponse()->getContent();
+
         self::assertContains('"name":"main-menu"', $content);
         self::assertContains('"label":"Main menu"', $content);
+
+        $client->request('GET', $this->router->generate('swp_api_templates_get_widget', ['id' => 1]));
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        self::assertEquals($client->getResponse()->getContent(), '{"id":1,"type":"SWP\\\\Bundle\\\\TemplatesSystemBundle\\\\Widget\\\\MenuWidgetHandler","name":"main-menu","visible":true,"parameters":{"menu_name":"main-menu"},"_links":{"self":{"href":"\/api\/v1\/templates\/widgets\/1"}}}');
     }
 
     public function testCreateMenuItemsWithTheSameNamesApi()
@@ -140,6 +149,36 @@ class MenuControllerTest extends WebTestCase
         self::assertEquals($client->getResponse()->getContent(), '');
 
         $client->request('GET', $this->router->generate('swp_api_core_get_menu', ['id' => 1]));
+        self::assertEquals(404, $client->getResponse()->getStatusCode());
+    }
+
+    public function testDeleteMenuAndMenuWidgetApi()
+    {
+        $client = static::createClient();
+        $client->request('POST', $this->router->generate('swp_api_core_create_menu'), [
+            'menu' => [
+                'name' => 'main-menu',
+                'label' => 'Main menu',
+            ],
+        ]);
+
+        self::assertEquals(201, $client->getResponse()->getStatusCode());
+        $content = $client->getResponse()->getContent();
+        self::assertContains('"name":"main-menu"', $content);
+        self::assertContains('"label":"Main menu"', $content);
+
+        $client->request('GET', $this->router->generate('swp_api_templates_get_widget', ['id' => 1]));
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        self::assertEquals($client->getResponse()->getContent(), '{"id":1,"type":"SWP\\\\Bundle\\\\TemplatesSystemBundle\\\\Widget\\\\MenuWidgetHandler","name":"main-menu","visible":true,"parameters":{"menu_name":"main-menu"},"_links":{"self":{"href":"\/api\/v1\/templates\/widgets\/1"}}}');
+
+        $content = json_decode($content, true);
+        $client->request('DELETE', $this->router->generate('swp_api_core_delete_menu', ['id' => $content['id']]));
+
+        self::assertEquals(204, $client->getResponse()->getStatusCode());
+        self::assertEquals($client->getResponse()->getContent(), '');
+
+        $client->request('GET', $this->router->generate('swp_api_templates_get_widget', ['id' => 1]));
         self::assertEquals(404, $client->getResponse()->getStatusCode());
     }
 

--- a/src/SWP/Bundle/CoreBundle/spec/EventListener/MenuWidgetCreateListenerSpec.php
+++ b/src/SWP/Bundle/CoreBundle/spec/EventListener/MenuWidgetCreateListenerSpec.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+declare(strict_types=1);
+
+namespace spec\SWP\Bundle\CoreBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use SWP\Bundle\CoreBundle\EventListener\MenuWidgetCreateListener;
+use SWP\Bundle\MenuBundle\Model\MenuItemInterface;
+use SWP\Component\Common\Exception\UnexpectedTypeException;
+use SWP\Component\Storage\Factory\FactoryInterface;
+use SWP\Component\Storage\Repository\RepositoryInterface;
+use SWP\Component\TemplatesSystem\Gimme\Model\WidgetModelInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class MenuWidgetCreateListenerSpec extends ObjectBehavior
+{
+    function let(FactoryInterface $widgetFactory, RepositoryInterface $widgetRepository)
+    {
+        $this->beConstructedWith($widgetFactory, $widgetRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MenuWidgetCreateListener::class);
+    }
+
+    function it_throws_exception(
+        GenericEvent $event,
+        \stdClass $menuItem
+    ) {
+        $event->getSubject()->willReturn($menuItem);
+
+        $this->shouldThrow(UnexpectedTypeException::class)
+            ->duringOnMenuCreated($event);
+    }
+
+    function it_creates_menu_widget_on_menu_created_event(
+        GenericEvent $event,
+        MenuItemInterface $menuItem,
+        FactoryInterface $widgetFactory,
+        RepositoryInterface $widgetRepository,
+        WidgetModelInterface $widget
+    ) {
+        $menuItem->getName()->willReturn('menuNav');
+        $menuItem->getParent()->willReturn(null);
+        $event->getSubject()->willReturn($menuItem);
+
+        $widget->setType(WidgetModelInterface::TYPE_MENU)->shouldBeCalled();
+        $widget->setName('menuNav')->shouldBeCalled();
+        $widget->setParameters(['menu_name' => 'menuNav'])->shouldBeCalled();
+        $widgetFactory->create()->willReturn($widget);
+
+        $widgetRepository->add($widget)->shouldBeCalled();
+
+        $this->onMenuCreated($event);
+    }
+
+    function it_creates_menu_widget_only_for_root_menus(
+        GenericEvent $event,
+        MenuItemInterface $menuItem,
+        FactoryInterface $widgetFactory,
+        RepositoryInterface $widgetRepository,
+        WidgetModelInterface $widget
+    ) {
+        $menuItem->getName()->willReturn('menuNav');
+        $menuItem->getParent()->willReturn(2);
+        $event->getSubject()->willReturn($menuItem);
+
+        $widget->setType(WidgetModelInterface::TYPE_MENU)->shouldNotBeCalled();
+        $widget->setName('menuNav')->shouldNotBeCalled();
+        $widget->setParameters(['menu_name' => 'menuNav'])->shouldNotBeCalled();
+        $widgetFactory->create()->shouldNotBeCalled();
+
+        $widgetRepository->add($widget)->shouldNotBeCalled();
+
+        $this->onMenuCreated($event);
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/spec/EventListener/MenuWidgetDeleteListenerSpec.php
+++ b/src/SWP/Bundle/CoreBundle/spec/EventListener/MenuWidgetDeleteListenerSpec.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+declare(strict_types=1);
+
+namespace spec\SWP\Bundle\CoreBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use SWP\Bundle\CoreBundle\EventListener\MenuWidgetDeleteListener;
+use SWP\Bundle\MenuBundle\Model\MenuItemInterface;
+use SWP\Component\Common\Exception\UnexpectedTypeException;
+use SWP\Component\Storage\Repository\RepositoryInterface;
+use SWP\Component\TemplatesSystem\Gimme\Model\WidgetModelInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class MenuWidgetDeleteListenerSpec extends ObjectBehavior
+{
+    function let(RepositoryInterface $widgetRepository)
+    {
+        $this->beConstructedWith($widgetRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MenuWidgetDeleteListener::class);
+    }
+
+    function it_throws_exception(
+        GenericEvent $event,
+        \stdClass $menuItem
+    ) {
+        $event->getSubject()->willReturn($menuItem);
+
+        $this->shouldThrow(UnexpectedTypeException::class)
+            ->duringOnMenuDeleted($event);
+    }
+
+    function it_deletes_menu_widget_on_menu_deleted_event(
+        GenericEvent $event,
+        MenuItemInterface $menuItem,
+        RepositoryInterface $widgetRepository,
+        WidgetModelInterface $widget
+    ) {
+        $menuItem->getName()->willReturn('menuNav');
+        $menuItem->getParent()->willReturn(null);
+        $event->getSubject()->willReturn($menuItem);
+
+        $widgetRepository->findOneBy(['name' => 'menuNav'])->willReturn($widget);
+        $widgetRepository->remove($widget)->shouldBeCalled();
+
+        $this->onMenuDeleted($event);
+    }
+
+    function it_deletes_menu_widget_only_for_root_menus(
+        GenericEvent $event,
+        MenuItemInterface $menuItem,
+        RepositoryInterface $widgetRepository,
+        WidgetModelInterface $widget
+    ) {
+        $menuItem->getName()->willReturn('menuNav');
+        $menuItem->getParent()->willReturn(1);
+        $event->getSubject()->willReturn($menuItem);
+
+        $widgetRepository->findOneBy(['name' => 'menuNav'])->shouldNotBeCalled();
+        $widgetRepository->remove($widget)->shouldNotBeCalled();
+
+        $this->onMenuDeleted($event);
+    }
+
+    function it_does_nothing_when_widget_does_not_exist(
+        GenericEvent $event,
+        MenuItemInterface $menuItem,
+        RepositoryInterface $widgetRepository,
+        WidgetModelInterface $widget
+    ) {
+        $menuItem->getName()->willReturn('menuNav');
+        $menuItem->getParent()->willReturn(1);
+        $event->getSubject()->willReturn($menuItem);
+
+        $widgetRepository->findOneBy(['name' => 'menuNav'])->willReturn(null);
+        $widgetRepository->remove($widget)->shouldNotBeCalled();
+
+        $this->onMenuDeleted($event);
+    }
+}

--- a/src/SWP/Bundle/MenuBundle/MenuEvents.php
+++ b/src/SWP/Bundle/MenuBundle/MenuEvents.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Menu Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\MenuBundle;
+
+final class MenuEvents
+{
+    /**
+     * The MENU_CREATED event occurs after menu is created.
+     *
+     * @Event("Symfony\Component\EventDispatcher\GenericEvent")
+     *
+     * @var string
+     */
+    const MENU_CREATED = 'swp.menu.created';
+
+    /**
+     * The MENU_DELETED event occurs after menu is deleted.
+     *
+     * @Event("Symfony\Component\EventDispatcher\GenericEvent")
+     *
+     * @var string
+     */
+    const MENU_DELETED = 'swp.menu.deleted';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/SWP/Bundle/TemplatesSystemBundle/DependencyInjection/Configuration.php
+++ b/src/SWP/Bundle/TemplatesSystemBundle/DependencyInjection/Configuration.php
@@ -23,7 +23,9 @@ use SWP\Bundle\TemplatesSystemBundle\Model\ContainerData;
 use SWP\Bundle\TemplatesSystemBundle\Model\ContainerWidget;
 use SWP\Bundle\TemplatesSystemBundle\Model\WidgetModel;
 use SWP\Bundle\TemplatesSystemBundle\Repository\ContainerRepository;
+use SWP\Bundle\TemplatesSystemBundle\Repository\ContainerWidgetRepository;
 use SWP\Bundle\TemplatesSystemBundle\Repository\WidgetModelRepository;
+use SWP\Component\Storage\Factory\Factory;
 use SWP\Component\TemplatesSystem\Gimme\Model\ContainerDataInterface;
 use SWP\Component\TemplatesSystem\Gimme\Model\ContainerInterface;
 use SWP\Component\TemplatesSystem\Gimme\Model\ContainerWidgetInterface;
@@ -82,7 +84,7 @@ class Configuration implements ConfigurationInterface
                                                 ->scalarNode('model')->cannotBeEmpty()->defaultValue(WidgetModel::class)->end()
                                                 ->scalarNode('interface')->cannotBeEmpty()->defaultValue(WidgetModelInterface::class)->end()
                                                 ->scalarNode('repository')->defaultValue(WidgetModelRepository::class)->end()
-                                                ->scalarNode('factory')->defaultValue(null)->end()
+                                                ->scalarNode('factory')->defaultValue(Factory::class)->end()
                                                 ->scalarNode('object_manager_name')->defaultValue(null)->end()
                                             ->end()
                                         ->end()
@@ -91,7 +93,7 @@ class Configuration implements ConfigurationInterface
                                             ->children()
                                                 ->scalarNode('model')->cannotBeEmpty()->defaultValue(ContainerWidget::class)->end()
                                                 ->scalarNode('interface')->cannotBeEmpty()->defaultValue(ContainerWidgetInterface::class)->end()
-                                                ->scalarNode('repository')->defaultValue(null)->end()
+                                                ->scalarNode('repository')->defaultValue(ContainerWidgetRepository::class)->end()
                                                 ->scalarNode('factory')->defaultValue(null)->end()
                                                 ->scalarNode('object_manager_name')->defaultValue(null)->end()
                                             ->end()

--- a/src/SWP/Bundle/TemplatesSystemBundle/DependencyInjection/Configuration.php
+++ b/src/SWP/Bundle/TemplatesSystemBundle/DependencyInjection/Configuration.php
@@ -23,7 +23,6 @@ use SWP\Bundle\TemplatesSystemBundle\Model\ContainerData;
 use SWP\Bundle\TemplatesSystemBundle\Model\ContainerWidget;
 use SWP\Bundle\TemplatesSystemBundle\Model\WidgetModel;
 use SWP\Bundle\TemplatesSystemBundle\Repository\ContainerRepository;
-use SWP\Bundle\TemplatesSystemBundle\Repository\ContainerWidgetRepository;
 use SWP\Bundle\TemplatesSystemBundle\Repository\WidgetModelRepository;
 use SWP\Component\Storage\Factory\Factory;
 use SWP\Component\TemplatesSystem\Gimme\Model\ContainerDataInterface;
@@ -93,7 +92,7 @@ class Configuration implements ConfigurationInterface
                                             ->children()
                                                 ->scalarNode('model')->cannotBeEmpty()->defaultValue(ContainerWidget::class)->end()
                                                 ->scalarNode('interface')->cannotBeEmpty()->defaultValue(ContainerWidgetInterface::class)->end()
-                                                ->scalarNode('repository')->defaultValue(ContainerWidgetRepository::class)->end()
+                                                ->scalarNode('repository')->defaultValue(null)->end()
                                                 ->scalarNode('factory')->defaultValue(null)->end()
                                                 ->scalarNode('object_manager_name')->defaultValue(null)->end()
                                             ->end()

--- a/src/SWP/Bundle/TemplatesSystemBundle/Form/Type/WidgetType.php
+++ b/src/SWP/Bundle/TemplatesSystemBundle/Form/Type/WidgetType.php
@@ -35,23 +35,27 @@ class WidgetType extends AbstractType
             ])
             ->add('parameters', TextType::class, [
                 'required' => false,
-            ])
+            ]);
+
+        $builder->get('parameters')
             ->addModelTransformer(new CallbackTransformer(
-                function ($originalDescription) {
-                    if ($originalDescription && is_array($originalDescription->getParameters())) {
-                        $originalDescription->setParameters(json_encode($originalDescription->getParameters()));
+                function ($value) {
+                    if (is_array($value) && !empty($value)) {
+                        return json_encode($value);
                     }
 
-                    return $originalDescription;
+                    return $value;
                 },
-                function ($submittedDescription) {
-                    if ($submittedDescription && is_string($submittedDescription->getParameters())) {
-                        $submittedDescription->setParameters(json_decode($submittedDescription->getParameters(), true));
-                    } elseif ($submittedDescription && !is_array($submittedDescription->getParameters())) {
-                        $submittedDescription->setParameters([]);
+                function ($value) {
+                    if (is_string($value)) {
+                        return json_decode($value, true);
                     }
 
-                    return $submittedDescription;
+                    if (null === $value) {
+                        return [];
+                    }
+
+                    return $value;
                 }
             ));
     }

--- a/src/SWP/Bundle/TemplatesSystemBundle/Model/WidgetModel.php
+++ b/src/SWP/Bundle/TemplatesSystemBundle/Model/WidgetModel.php
@@ -191,11 +191,11 @@ class WidgetModel implements WidgetModelInterface, TimestampableInterface
     /**
      * Sets the value of parameters.
      *
-     * @param [] $parameters the parameters
+     * @param array $parameters the parameters
      *
      * @return WidgetModel
      */
-    public function setParameters($parameters = [])
+    public function setParameters(array $parameters = [])
     {
         $this->parameters = $parameters;
 

--- a/src/SWP/Bundle/TemplatesSystemBundle/Model/WidgetModel.php
+++ b/src/SWP/Bundle/TemplatesSystemBundle/Model/WidgetModel.php
@@ -26,10 +26,6 @@ use SWP\Component\TemplatesSystem\Gimme\Widget\HtmlWidgetHandler;
  */
 class WidgetModel implements WidgetModelInterface, TimestampableInterface
 {
-    const TYPE_HTML = 1;
-    const TYPE_ADSENSE = 2;
-    const TYPE_MENU = 3;
-
     protected $types = [
         self::TYPE_HTML => HtmlWidgetHandler::class,
         self::TYPE_ADSENSE => GoogleAdSenseWidgetHandler::class,

--- a/src/SWP/Bundle/TemplatesSystemBundle/Repository/WidgetModelRepository.php
+++ b/src/SWP/Bundle/TemplatesSystemBundle/Repository/WidgetModelRepository.php
@@ -15,12 +15,11 @@
 namespace SWP\Bundle\TemplatesSystemBundle\Repository;
 
 use SWP\Bundle\StorageBundle\Doctrine\ORM\EntityRepository;
-use SWP\Component\Storage\Repository\RepositoryInterface;
 
 /**
  * Container Repository.
  */
-class WidgetModelRepository extends EntityRepository implements RepositoryInterface
+class WidgetModelRepository extends EntityRepository
 {
     /**
      * Get Query for WidgetModel searched by id.

--- a/src/SWP/Bundle/TemplatesSystemBundle/Repository/WidgetModelRepository.php
+++ b/src/SWP/Bundle/TemplatesSystemBundle/Repository/WidgetModelRepository.php
@@ -14,12 +14,13 @@
 
 namespace SWP\Bundle\TemplatesSystemBundle\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use SWP\Bundle\StorageBundle\Doctrine\ORM\EntityRepository;
+use SWP\Component\Storage\Repository\RepositoryInterface;
 
 /**
  * Container Repository.
  */
-class WidgetModelRepository extends EntityRepository
+class WidgetModelRepository extends EntityRepository implements RepositoryInterface
 {
     /**
      * Get Query for WidgetModel searched by id.

--- a/src/SWP/Component/Common/Exception/UnexpectedTypeException.php
+++ b/src/SWP/Component/Common/Exception/UnexpectedTypeException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Common Component.
+ *
+ * Copyright 2017 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Component\Common\Exception;
+
+class UnexpectedTypeException extends \InvalidArgumentException
+{
+    /**
+     * @param string $type
+     * @param string $expectedType
+     *
+     * @return UnexpectedTypeException
+     */
+    public static function unexpectedType(string $type, string $expectedType): self
+    {
+        return new self(sprintf(
+            'Expected argument of type "%s", "%s" given.',
+            $expectedType,
+            $type
+        ));
+    }
+}

--- a/src/SWP/Component/TemplatesSystem/Gimme/Model/WidgetModelInterface.php
+++ b/src/SWP/Component/TemplatesSystem/Gimme/Model/WidgetModelInterface.php
@@ -14,11 +14,17 @@
 
 namespace SWP\Component\TemplatesSystem\Gimme\Model;
 
+use SWP\Component\Storage\Model\PersistableInterface;
+
 /**
  * Container Interface.
  */
-interface WidgetModelInterface
+interface WidgetModelInterface extends PersistableInterface
 {
+    const TYPE_HTML = 1;
+    const TYPE_ADSENSE = 2;
+    const TYPE_MENU = 3;
+
     /**
      * Get widget Id.
      *
@@ -53,4 +59,25 @@ interface WidgetModelInterface
      * @return array
      */
     public function getParameters();
+
+    /**
+     * @param int $type
+     *
+     * @return self
+     */
+    public function setType($type = self::TYPE_HTML);
+
+    /**
+     * @param array $parameters
+     *
+     * @return self
+     */
+    public function setParameters($parameters = []);
+
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName($name);
 }

--- a/src/SWP/Component/TemplatesSystem/Gimme/Model/WidgetModelInterface.php
+++ b/src/SWP/Component/TemplatesSystem/Gimme/Model/WidgetModelInterface.php
@@ -72,7 +72,7 @@ interface WidgetModelInterface extends PersistableInterface
      *
      * @return self
      */
-    public function setParameters($parameters = []);
+    public function setParameters(array $parameters = []);
 
     /**
      * @param string $name

--- a/src/SWP/Component/TemplatesSystem/Tests/Gimme/Model/WidgetModel.php
+++ b/src/SWP/Component/TemplatesSystem/Tests/Gimme/Model/WidgetModel.php
@@ -21,8 +21,6 @@ use SWP\Component\TemplatesSystem\Gimme\Model\WidgetModelInterface;
  */
 class WidgetModel implements WidgetModelInterface
 {
-    const TYPE_HTML = 1;
-
     protected $types = [
         self::TYPE_HTML => '\\SWP\\Component\\TemplatesSystem\\Gimme\\WidgetModel\\HtmlWidgetHandler',
     ];
@@ -175,7 +173,7 @@ class WidgetModel implements WidgetModelInterface
      *
      * @return WidgetModel
      */
-    public function setParameters($parameters)
+    public function setParameters(array $parameters = [])
     {
         $this->parameters = $parameters;
 


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | yes
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | yes
| Fixed tickets             | SWP-563
| License                   | AGPLv3

TODO:
- [x] - functional tests
- [x] - docs
- [x] - remove widget when menu is removed