### PR TITLE
extend menu manager, assign route's url

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Controller/MenuController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/MenuController.php
@@ -151,20 +151,15 @@ class MenuController extends Controller
      */
     public function createAction(Request $request)
     {
-        $route = null;
-        if (array_key_exists('route', $request->request->get('menu'))) {
-            $route = $this->get('swp.repository.route')->findOneBy(['id' => $request->request->get('menu')['route']]);
-        }
-
         /* @var MenuItemInterface $menu */
-        $menu = $this->get('swp.factory.menu')->createItem('', ['route' => $route ? $route->getName() : null]);
+        $menu = $this->get('swp.factory.menu')->create();
         $form = $this->createForm(MenuType::class, $menu, ['method' => $request->getMethod()]);
 
         $form->handleRequest($request);
 
         if ($form->isValid()) {
+            $this->get('swp_menu.manager.menu_item')->update($menu);
             $this->get('swp.repository.menu')->add($menu);
-
             $this->get('event_dispatcher')->dispatch(MenuEvents::MENU_CREATED, new GenericEvent($menu));
 
             return new SingleResourceResponse($menu, new ResponseContext(201));

--- a/src/SWP/Bundle/CoreBundle/Manager/MenuItemManager.php
+++ b/src/SWP/Bundle/CoreBundle/Manager/MenuItemManager.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Manager;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Knp\Menu\Factory\ExtensionInterface;
+use SWP\Bundle\ContentBundle\Model\RouteAwareInterface;
+use SWP\Bundle\MenuBundle\Doctrine\MenuItemRepositoryInterface;
+use SWP\Bundle\MenuBundle\Manager\MenuItemManager as BaseMenuItemManager;
+use SWP\Bundle\MenuBundle\Model\MenuItemInterface;
+
+final class MenuItemManager extends BaseMenuItemManager
+{
+    /**
+     * MenuItemManager constructor.
+     *
+     * @param MenuItemRepositoryInterface $menuItemRepository
+     * @param ObjectManager               $objectManager
+     * @param ExtensionInterface          $extensionsChain
+     */
+    public function __construct(
+        MenuItemRepositoryInterface $menuItemRepository,
+        ObjectManager $objectManager,
+        ExtensionInterface $extensionsChain
+    ) {
+        parent::__construct($menuItemRepository, $objectManager, $extensionsChain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update(MenuItemInterface $menu)
+    {
+        $options = [];
+
+        if ($menu instanceof RouteAwareInterface) {
+            $options = [
+                'route' => $menu->getRoute() ? $menu->getRoute()->getName() : null,
+            ];
+        }
+
+        parent::updateOptions($menu, $options);
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/Manager/MenuItemManager.php
+++ b/src/SWP/Bundle/CoreBundle/Manager/MenuItemManager.php
@@ -53,6 +53,6 @@ final class MenuItemManager extends BaseMenuItemManager
             ];
         }
 
-        parent::updateOptions($menu, $options);
+        $this->updateOptions($menu, $options);
     }
 }

--- a/src/SWP/Bundle/CoreBundle/Model/MenuItem.php
+++ b/src/SWP/Bundle/CoreBundle/Model/MenuItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Superdesk Web Publisher Core Bundle.
  *
@@ -14,13 +16,11 @@
 
 namespace SWP\Bundle\CoreBundle\Model;
 
-use SWP\Bundle\ContentBundle\Model\RouteAwareInterface;
 use SWP\Bundle\ContentBundle\Model\RouteAwareTrait;
 use SWP\Bundle\MenuBundle\Model\MenuItem as BaseMenuItem;
-use SWP\Component\MultiTenancy\Model\TenantAwareInterface;
 use SWP\Component\MultiTenancy\Model\TenantAwareTrait;
 
-class MenuItem extends BaseMenuItem implements TenantAwareInterface, RouteAwareInterface
+class MenuItem extends BaseMenuItem implements MenuItemInterface
 {
     use TenantAwareTrait, RouteAwareTrait;
 }

--- a/src/SWP/Bundle/CoreBundle/Model/MenuItemInterface.php
+++ b/src/SWP/Bundle/CoreBundle/Model/MenuItemInterface.php
@@ -17,8 +17,9 @@ declare(strict_types=1);
 namespace SWP\Bundle\CoreBundle\Model;
 
 use SWP\Bundle\ContentBundle\Model\RouteAwareInterface;
+use SWP\Bundle\MenuBundle\Model\MenuItemInterface as BaseMenuItemInterface;
 use SWP\Component\MultiTenancy\Model\TenantAwareInterface;
 
-interface MenuItemInterface extends TenantAwareInterface, RouteAwareInterface
+interface MenuItemInterface extends BaseMenuItemInterface, TenantAwareInterface, RouteAwareInterface
 {
 }

--- a/src/SWP/Bundle/CoreBundle/Model/MenuItemInterface.php
+++ b/src/SWP/Bundle/CoreBundle/Model/MenuItemInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Model;
+
+use SWP\Bundle\ContentBundle\Model\RouteAwareInterface;
+use SWP\Component\MultiTenancy\Model\TenantAwareInterface;
+
+interface MenuItemInterface extends TenantAwareInterface, RouteAwareInterface
+{
+}

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -195,3 +195,19 @@ services:
             - '@swp.repository.widget_model'
         tags:
             - { name: kernel.event_listener, event: swp.menu.deleted, method: onMenuDeleted }
+
+    swp_core.manager.menu_item:
+        class: SWP\Bundle\CoreBundle\Manager\MenuItemManager
+        arguments:
+            - "@swp.repository.menu"
+            - "@swp.object_manager.menu"
+            - "@swp_menu.extension_chain"
+
+    swp_core.decorating_manager.menu_item:
+        class: SWP\Bundle\CoreBundle\Manager\MenuItemManager
+        decorates: swp_menu.manager.menu_item
+        arguments:
+            - "@swp.repository.menu"
+            - "@swp.object_manager.menu"
+            - "@swp_menu.extension_chain"
+        public: false

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -196,13 +196,6 @@ services:
         tags:
             - { name: kernel.event_listener, event: swp.menu.deleted, method: onMenuDeleted }
 
-    swp_core.manager.menu_item:
-        class: SWP\Bundle\CoreBundle\Manager\MenuItemManager
-        arguments:
-            - "@swp.repository.menu"
-            - "@swp.object_manager.menu"
-            - "@swp_menu.extension_chain"
-
     swp_core.decorating_manager.menu_item:
         class: SWP\Bundle\CoreBundle\Manager\MenuItemManager
         decorates: swp_menu.manager.menu_item

--- a/src/SWP/Bundle/CoreBundle/spec/Manager/MenuItemManagerSpec.php
+++ b/src/SWP/Bundle/CoreBundle/spec/Manager/MenuItemManagerSpec.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace spec\SWP\Bundle\CoreBundle\Manager;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Knp\Menu\Factory\ExtensionInterface;
+use PhpSpec\ObjectBehavior;
+use SWP\Bundle\ContentBundle\Model\RouteInterface;
+use SWP\Bundle\CoreBundle\Manager\MenuItemManager;
+use SWP\Bundle\CoreBundle\Model\MenuItemInterface;
+use SWP\Bundle\MenuBundle\Doctrine\MenuItemRepositoryInterface;
+use SWP\Bundle\MenuBundle\Manager\MenuItemManagerInterface;
+
+final class MenuItemManagerSpec extends ObjectBehavior
+{
+    public function let(
+        MenuItemRepositoryInterface $menuItemRepository,
+        ObjectManager $objectManager,
+        ExtensionInterface $extensionChain
+    ) {
+        $this->beConstructedWith($menuItemRepository, $objectManager, $extensionChain);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(MenuItemManager::class);
+    }
+
+    public function it_implements_an_interface()
+    {
+        $this->shouldImplement(MenuItemManagerInterface::class);
+    }
+
+    public function it_updates_menu_options(
+        MenuItemInterface $menu,
+        ExtensionInterface $extensionChain,
+        RouteInterface $route
+    ) {
+        $route->getName()->willReturn('sports');
+
+        $menu->getLabel()->willReturn('testlabel');
+        $menu->getUri()->willReturn('/test');
+        $menu->getRoute()->willReturn($route);
+        $options = [
+            'uri' => '/test',
+            'label' => 'testlabel',
+            'route' => 'sports',
+        ];
+        $extensionChain->buildOptions($options)->shouldBeCalled()->willReturn($options);
+        $extensionChain->buildItem($menu, $options)->shouldBeCalled();
+        $this->update($menu);
+    }
+
+    public function it_updates_menu_options_when_route_empty(
+        MenuItemInterface $menu,
+        ExtensionInterface $extensionChain
+    ) {
+        $menu->getLabel()->willReturn('testlabel');
+        $menu->getUri()->willReturn('/test');
+        $menu->getRoute()->willReturn(null);
+        $options = [
+            'uri' => '/test',
+            'label' => 'testlabel',
+            'route' => null,
+        ];
+        $extensionChain->buildOptions($options)->shouldBeCalled()->willReturn($options);
+        $extensionChain->buildItem($menu, $options)->shouldBeCalled();
+        $this->update($menu);
+    }
+}

--- a/src/SWP/Bundle/MenuBundle/Form/Type/MenuType.php
+++ b/src/SWP/Bundle/MenuBundle/Form/Type/MenuType.php
@@ -20,8 +20,6 @@ use SWP\Bundle\ContentBundle\Form\Type\RouteSelectorType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -53,19 +51,6 @@ class MenuType extends AbstractType
                 'required' => false,
                 'description' => 'Route identifier (e.g. 10)',
             ]);
-
-        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
-            $menuItem = $event->getData();
-            $form = $event->getForm();
-
-            if (null !== $form->get('route')->getData() && null !== $form->get('uri')->getData()) {
-                $form->add('uri', TextType::class, ['empty_data' => $menuItem->getUri()]);
-            }
-
-            if (null === $form->get('route')->getData() && null !== $form->get('uri')->getData()) {
-                $form->get('uri')->setData(null);
-            }
-        });
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/SWP/Bundle/MenuBundle/spec/Manager/MenuItemManagerSpec.php
+++ b/src/SWP/Bundle/MenuBundle/spec/Manager/MenuItemManagerSpec.php
@@ -142,4 +142,19 @@ final class MenuItemManagerSpec extends ObjectBehavior
         $this->shouldThrow(HttpException::class)
             ->duringMove($sourceItem, $parentItem, 2);
     }
+
+    public function it_updates_menu_options(
+        MenuItemInterface $menu,
+        ExtensionInterface $extensionChain
+    ) {
+        $menu->getLabel()->willReturn('testlabel');
+        $menu->getUri()->willReturn('/test');
+        $options = [
+            'uri' => '/test',
+            'label' => 'testlabel',
+        ];
+        $extensionChain->buildOptions($options)->shouldBeCalled()->willReturn($options);
+        $extensionChain->buildItem($menu, $options)->shouldBeCalled();
+        $this->update($menu);
+    }
 }


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | yes
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | no
| Fixed tickets             | SWP-564, SWP-587
| License                   | AGPLv3


Route has a precedense before the uri, i.e. if route is set and you want to set custom uri, you need to first unassign route so the uri can take the precedense.