### PR TITLE
SWP- 740 - fixed issue with adding articles to content list on publish

### DIFF
--- a/src/SWP/Bundle/ContentListBundle/Doctrine/ORM/ContentListRepository.php
+++ b/src/SWP/Bundle/ContentListBundle/Doctrine/ORM/ContentListRepository.php
@@ -24,11 +24,13 @@ class ContentListRepository extends EntityRepository implements ContentListRepos
     /**
      * {@inheritdoc}
      */
-    public function findByType(string $type): array
+    public function findByTypes(array $types): array
     {
-        return $this->createQueryBuilder('cl')
-            ->where('cl.type = :type')
-            ->setParameter('type', $type)
+        $queryBuilder = $this->createQueryBuilder('cl');
+
+        return $queryBuilder
+            ->where($queryBuilder->expr()->in('cl.type', ':types'))
+            ->setParameter('types', $types)
             ->getQuery()
             ->getResult()
         ;

--- a/src/SWP/Bundle/CoreBundle/EventListener/AddArticleToListListener.php
+++ b/src/SWP/Bundle/CoreBundle/EventListener/AddArticleToListListener.php
@@ -28,7 +28,7 @@ use SWP\Component\ContentList\Repository\ContentListRepositoryInterface;
 use SWP\Component\Storage\Factory\FactoryInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class AutomaticListAddArticleListener
+class AddArticleToListListener
 {
     /**
      * @var ContentListRepositoryInterface
@@ -77,7 +77,10 @@ class AutomaticListAddArticleListener
     {
         $article = $event->getArticle();
         /** @var ContentListInterface[] $contentLists */
-        $contentLists = $this->listRepository->findAll();
+        $contentLists = $this->listRepository->findByTypes([
+            ContentListInterface::TYPE_AUTOMATIC,
+            ContentListInterface::TYPE_BUCKET,
+        ]);
 
         foreach ($contentLists as $contentList) {
             $filters = $contentList->getFilters();

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -89,7 +89,7 @@ services:
             - { name: kernel.event_subscriber }
 
     swp_core.listener.article_content_list:
-        class: SWP\Bundle\CoreBundle\EventListener\AutomaticListAddArticleListener
+        class: SWP\Bundle\CoreBundle\EventListener\AddArticleToListListener
         arguments:
             - '@swp.repository.content_list'
             - '@swp.factory.content_list_item'

--- a/src/SWP/Bundle/CoreBundle/spec/EventListener/AddArticleToListListenerSpec.php
+++ b/src/SWP/Bundle/CoreBundle/spec/EventListener/AddArticleToListListenerSpec.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Prophecy\Argument;
 use SWP\Bundle\ContentBundle\Event\ArticleEvent;
 use SWP\Bundle\ContentListBundle\Event\ContentListEvent;
-use SWP\Bundle\CoreBundle\EventListener\AutomaticListAddArticleListener;
+use SWP\Bundle\CoreBundle\EventListener\AddArticleToListListener;
 use PhpSpec\ObjectBehavior;
 use SWP\Bundle\CoreBundle\Matcher\ArticleCriteriaMatcherInterface;
 use SWP\Bundle\CoreBundle\Model\Article;
@@ -30,10 +30,7 @@ use SWP\Component\ContentList\Repository\ContentListRepositoryInterface;
 use SWP\Component\Storage\Factory\FactoryInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-/**
- * @mixin AutomaticListAddArticleListener
- */
-final class AutomaticListAddArticleListenerSpec extends ObjectBehavior
+final class AddArticleToListListenerSpec extends ObjectBehavior
 {
     public function let(
         ContentListRepositoryInterface $listRepository,
@@ -51,7 +48,7 @@ final class AutomaticListAddArticleListenerSpec extends ObjectBehavior
 
     public function it_is_initializable()
     {
-        $this->shouldHaveType(AutomaticListAddArticleListener::class);
+        $this->shouldHaveType(AddArticleToListListener::class);
     }
 
     public function it_adds_article_to_list(
@@ -68,7 +65,7 @@ final class AutomaticListAddArticleListenerSpec extends ObjectBehavior
 
         $list->getFilters()->willReturn(['metadata' => ['locale' => 'en']]);
         $list->getItems()->willReturn(new ArrayCollection());
-        $listRepository->findAll()->willReturn([$list]);
+        $listRepository->findByTypes(['automatic', 'bucket'])->willReturn([$list]);
 
         $articleCriteriaMatcher->match($article, new Criteria(['metadata' => ['locale' => 'en']]))->willReturn(true);
 
@@ -101,7 +98,7 @@ final class AutomaticListAddArticleListenerSpec extends ObjectBehavior
 
         $list->getFilters()->willReturn(['metadata' => ['locale' => 'en']]);
         $list->getItems()->willReturn(new ArrayCollection());
-        $listRepository->findAll()->willReturn([$list]);
+        $listRepository->findByTypes(['automatic', 'bucket'])->willReturn([$list]);
 
         $articleCriteriaMatcher->match($article, new Criteria(['metadata' => ['locale' => 'en']]))->willReturn(false);
 

--- a/src/SWP/Component/ContentList/Repository/ContentListRepositoryInterface.php
+++ b/src/SWP/Component/ContentList/Repository/ContentListRepositoryInterface.php
@@ -22,11 +22,11 @@ use SWP\Component\Storage\Repository\RepositoryInterface;
 interface ContentListRepositoryInterface extends RepositoryInterface
 {
     /**
-     * @param string $type
+     * @param array $types
      *
      * @return array
      */
-    public function findByType(string $type): array;
+    public function findByTypes(array $types): array;
 
     /**
      * @param int $listId


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | no
| Deprecations?             | yes
| Tests pass?               | yes
| Changelog update required | no
| Fixed tickets             | SWP-740
| License                   | AGPLv3

Articles, when they are published, should be added to automatic content lists and to the buckets only, not to the manual lists.