### PR TITLE
Pass List Id to content list widget

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Widget/ContentListWidget.php
+++ b/src/SWP/Bundle/CoreBundle/Widget/ContentListWidget.php
@@ -18,7 +18,6 @@ namespace SWP\Bundle\CoreBundle\Widget;
 
 use SWP\Bundle\TemplatesSystemBundle\Widget\TemplatingWidgetHandler;
 use SWP\Component\ContentList\Model\ContentListInterface;
-use SWP\Component\ContentList\Repository\ContentListRepositoryInterface;
 
 final class ContentListWidget extends TemplatingWidgetHandler
 {
@@ -40,13 +39,12 @@ final class ContentListWidget extends TemplatingWidgetHandler
         $templateName = $this->getModelParameter('template_name');
         $listId = (int) $this->getModelParameter('list_id');
 
-        /** @var ContentListRepositoryInterface $contentListRepository */
-        $contentListRepository = $this->getContainer()->get('swp.repository.content_list');
         /** @var ContentListInterface $contentList */
-        $contentList = $contentListRepository->findListById($listId);
+        $contentList = $this->getContainer()->get('swp.repository.content_list')->findListById($listId);
 
         return $this->renderTemplate($templateName, [
             'contentList' => $contentList,
+            'listId' => $listId,
         ]);
     }
 }

--- a/src/SWP/Bundle/CoreBundle/spec/Widget/ContentListWidgetSpec.php
+++ b/src/SWP/Bundle/CoreBundle/spec/Widget/ContentListWidgetSpec.php
@@ -62,6 +62,7 @@ final class ContentListWidgetSpec extends ObjectBehavior
         $contentListRepository->findListById(8)->willReturn($contentList);
         $templating->render('widgets/list.html.twig', [
             'contentList' => $contentList,
+            'listId' => 8,
         ])->willReturn($response);
 
         $this->render()->shouldReturn($response);
@@ -92,6 +93,7 @@ final class ContentListWidgetSpec extends ObjectBehavior
         $contentListRepository->findListById(8)->willReturn($contentList);
         $templating->render('widgets/custom.html.twig', [
             'contentList' => $contentList,
+            'listId' => 8,
         ])->willReturn($response);
 
         $this->render()->shouldReturn($response);


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | yes
| BC breaks?                | no
| Deprecations?             | yes
| Tests pass?               | yes
| Changelog update required | no
| Fixed tickets             | SWP-607
| License                   | AGPLv3

DEPRECATION:

From now you should use manual fetching content list items in content list widget templates. Content list loader is much more powerful than iteration on raw list data.

Documentation for content list items loader is here: http://superdesk-publisher.readthedocs.io/en/latest/manual/templates_system/content_list.html 
