### PR TITLE
add liveblog widget, implement externall esi renderer (fallback to curl when no ESI support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog references the relevant changes (bug and security fixes) done in 
 To get the diff for a specific change, go to https://github.com/superdesk/web-publisher/commit/XXX where XXX is the change hash
 
 * 1.1.x
+ * feature [#372] Add Liveblog widget, add external ESI renderer
  * feature [#368] Add Content List Loader
 
 * 1.1.0

--- a/app/Resources/views/widgets/liveblog.html.twig
+++ b/app/Resources/views/widgets/liveblog.html.twig
@@ -1,0 +1,1 @@
+{{ render_external_esi(url) }}

--- a/docs/cookbooks/developers/widgets.rst
+++ b/docs/cookbooks/developers/widgets.rst
@@ -79,6 +79,7 @@ By default there are three types of widgets bundled into the project:
 - HtmlWidget (default one)
 - GoogleAdsenseWidget
 - MenuWidget
+- LiveblogWidget
 
 ContentListWidget
 -----------------
@@ -94,3 +95,21 @@ This is the widget responsible for displaying Content Lists' items. For more det
 +--------------+---------------------------------+--------------+------------------+------------------+
 | template_name| Template name to render         | yes          | list.html.twig   |     string       |
 +--------------+---------------------------------+--------------+------------------+------------------+
+
+
+LiveblogWidget
+--------------
+
+This is the widget responsible for displaying  `Superdesk LiveBlog <https://liveblog.pro/>`_  embeds.
+
+**Default parameters:**
+
++--------------+---------------------------------+--------------+--------------------+------------------+
+| Parameter    | Description                     | Required?    | Default value      |      Type        |
++==============+=================================+==============+====================+==================+
+| uri          | Liveblog embed (fragment) uri   | yes          | N/A                |     string       |
++--------------+---------------------------------+--------------+--------------------+------------------+
+| template_name| Template name to render         | yes          | liveblog.html.twig |     string       |
++--------------+---------------------------------+--------------+--------------------+------------------+
+
+Default template file name: :code:`liveblog.html.twig` (default version provided by Publisher can be override by theme).

--- a/src/SWP/Bundle/CoreBundle/Fragment/ExternalEsiFragmentRenderer.php
+++ b/src/SWP/Bundle/CoreBundle/Fragment/ExternalEsiFragmentRenderer.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2016 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2016 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Fragment;
+
+use Symfony\Component\HttpKernel\Fragment\AbstractSurrogateFragmentRenderer;
+use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
+
+class ExternalEsiFragmentRenderer extends AbstractSurrogateFragmentRenderer implements FragmentRendererInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'external_esi';
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/Fragment/ExternalEsiFragmentRenderer.php
+++ b/src/SWP/Bundle/CoreBundle/Fragment/ExternalEsiFragmentRenderer.php
@@ -17,6 +17,9 @@ namespace SWP\Bundle\CoreBundle\Fragment;
 use Symfony\Component\HttpKernel\Fragment\AbstractSurrogateFragmentRenderer;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 
+/**
+ * Class ExternalEsiFragmentRenderer.
+ */
 class ExternalEsiFragmentRenderer extends AbstractSurrogateFragmentRenderer implements FragmentRendererInterface
 {
     /**

--- a/src/SWP/Bundle/CoreBundle/Fragment/ExternalFragmentRenderer.php
+++ b/src/SWP/Bundle/CoreBundle/Fragment/ExternalFragmentRenderer.php
@@ -23,9 +23,21 @@ use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
+/**
+ * Class ExternalFragmentRenderer.
+ *
+ * Render content fetched from external uri with guzzle.
+ */
 class ExternalFragmentRenderer implements FragmentRendererInterface
 {
+    /**
+     * @var HttpKernelInterface
+     */
     private $kernel;
+
+    /**
+     * @var EventDispatcherInterface
+     */
     private $dispatcher;
 
     /**
@@ -43,7 +55,7 @@ class ExternalFragmentRenderer implements FragmentRendererInterface
     /**
      * {@inheritdoc}
      */
-    public function render($uri, Request $request, array $options = array())
+    public function render($uri, Request $request, array $options = [])
     {
         $level = ob_get_level();
         try {

--- a/src/SWP/Bundle/CoreBundle/Model/WidgetModel.php
+++ b/src/SWP/Bundle/CoreBundle/Model/WidgetModel.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace SWP\Bundle\CoreBundle\Model;
 
 use SWP\Bundle\CoreBundle\Widget\ContentListWidget;
+use SWP\Bundle\CoreBundle\Widget\LiveblogWidgetHandler;
 use SWP\Bundle\TemplatesSystemBundle\Model\WidgetModel as BaseWidgetModel;
 use SWP\Component\MultiTenancy\Model\TenantAwareInterface;
 use SWP\Component\MultiTenancy\Model\TenantAwareTrait;
@@ -24,6 +25,7 @@ use SWP\Component\MultiTenancy\Model\TenantAwareTrait;
 class WidgetModel extends BaseWidgetModel implements WidgetModelInterface, TenantAwareInterface
 {
     const TYPE_LIST = 4;
+    const TYPE_LIVEBLOG = 5;
 
     use TenantAwareTrait;
 
@@ -34,6 +36,7 @@ class WidgetModel extends BaseWidgetModel implements WidgetModelInterface, Tenan
     {
         return parent::getTypes() + [
             self::TYPE_LIST => ContentListWidget::class,
+            self::TYPE_LIVEBLOG => LiveblogWidgetHandler::class,
         ];
     }
 }

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -287,3 +287,23 @@ services:
             - "@swp_template_engine_context"
         tags:
             - { name: swp.meta_loader.add }
+
+    swp_core.fragment.renderer.external:
+        class: SWP\Bundle\CoreBundle\Fragment\ExternalFragmentRenderer
+        arguments:
+            - "@kernel"
+            - "@event_dispatcher"
+        public: false
+
+    swp_core.fragment.renderer.external_esi:
+        class: SWP\Bundle\CoreBundle\Fragment\ExternalEsiFragmentRenderer
+        arguments:
+            - "@esi"
+            - "@swp_core.fragment.renderer.external"
+            - "@uri_signer"
+        tags:
+            - { name: kernel.fragment_renderer, alias: external_esi }
+        calls:
+            - method: setFragmentPath
+              arguments:
+                  - '%fragment.path%'

--- a/src/SWP/Bundle/CoreBundle/Tests/Fragment/ExternalFragmentRendererTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Fragment/ExternalFragmentRendererTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2016 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2016 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Tests\Fragment;
+
+use Superdesk\ContentApiSdk\Exception\ClientException;
+use SWP\Bundle\CoreBundle\Fragment\ExternalFragmentRenderer;
+use SWP\Bundle\FixturesBundle\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ExternalFragmentRendererTest extends WebTestCase
+{
+    protected $renderer;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        self::bootKernel();
+
+        $this->renderer = new ExternalFragmentRenderer(
+            $this->getContainer()->get('kernel'),
+            $this->getContainer()->get('event_dispatcher')
+        );
+    }
+
+    public function testRendering()
+    {
+        $content = json_decode($this->renderer->render('localhost:3000/esi_fragment', new Request())->getContent(), true);
+        self::assertEquals(['content' => 'some content'], $content);
+    }
+
+    public function testRenderingAlternativeContent()
+    {
+        $content = json_decode($this->renderer->render('localhost:3001/404', new Request(), [
+            'alt' => 'localhost:3000/esi_fragment',
+        ])->getContent(), true);
+        self::assertEquals(['content' => 'some content'], $content);
+    }
+
+    public function testRenderingWithErrors()
+    {
+        $this->expectException(ClientException::class);
+        $content = json_decode($this->renderer->render('localhost:3001/404', new Request(), [
+            'ignore_errors' => false,
+        ])->getContent(), true);
+        self::assertEquals(['content' => 'some content'], $content);
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/Tests/Functional/ArticleTitleChangeTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Functional/ArticleTitleChangeTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @license http://www.superdesk.org/license
  */
 
-namespace SWP\Bundle\CoreBundle\Tests\Functional\Controller;
+namespace SWP\Bundle\CoreBundle\Tests\Functional;
 
 use SWP\Bundle\FixturesBundle\WebTestCase;
 use Symfony\Component\Routing\RouterInterface;

--- a/src/SWP/Bundle/CoreBundle/Tests/Functional/Resources/db.json
+++ b/src/SWP/Bundle/CoreBundle/Tests/Functional/Resources/db.json
@@ -22,5 +22,8 @@
         "sign_off": "testu"
       }
     }
-  ]
+  ],
+  "esi_fragment": {
+    "content": "some content"
+  }
 }

--- a/src/SWP/Bundle/CoreBundle/Tests/Functional/Resources/routes.json
+++ b/src/SWP/Bundle/CoreBundle/Tests/Functional/Resources/routes.json
@@ -1,3 +1,4 @@
 {
-  "/api/sessions/:id": "/sessions/:id"
+  "/api/sessions/:id": "/sessions/:id",
+  "/api/esi_fragment": "/esi_fragment"
 }

--- a/src/SWP/Bundle/CoreBundle/Widget/LiveblogWidgetHandler.php
+++ b/src/SWP/Bundle/CoreBundle/Widget/LiveblogWidgetHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Widget;
+
+use SWP\Bundle\TemplatesSystemBundle\Widget\TemplatingWidgetHandler;
+
+class LiveblogWidgetHandler extends TemplatingWidgetHandler
+{
+    const TEMPLATE_NAME = 'liveblog.html.twig';
+
+    protected static $expectedParameters = [
+        'url' => [
+            'type' => 'string',
+        ],
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render()
+    {
+        $url = $this->getModelParameter('url');
+        dump(self::TEMPLATE_NAME, $url);
+
+        return $this->renderTemplate(self::TEMPLATE_NAME, [
+            'url' => $url,
+        ]);
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/Widget/LiveblogWidgetHandler.php
+++ b/src/SWP/Bundle/CoreBundle/Widget/LiveblogWidgetHandler.php
@@ -26,6 +26,10 @@ class LiveblogWidgetHandler extends TemplatingWidgetHandler
         'url' => [
             'type' => 'string',
         ],
+        'template_name' => [
+            'type' => 'string',
+            'default' => self::TEMPLATE_NAME,
+        ],
     ];
 
     /**
@@ -33,11 +37,8 @@ class LiveblogWidgetHandler extends TemplatingWidgetHandler
      */
     public function render()
     {
-        $url = $this->getModelParameter('url');
-        dump(self::TEMPLATE_NAME, $url);
-
-        return $this->renderTemplate(self::TEMPLATE_NAME, [
-            'url' => $url,
+        return $this->renderTemplate($this->getModelParameter('template_name'), [
+            'url' => $this->getModelParameter('url'),
         ]);
     }
 }

--- a/src/SWP/Bundle/CoreBundle/spec/Widget/LiveblogWidgetHandlerSpec.php
+++ b/src/SWP/Bundle/CoreBundle/spec/Widget/LiveblogWidgetHandlerSpec.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2017 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2017 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace spec\SWP\Bundle\CoreBundle\Widget;
+
+use PhpSpec\ObjectBehavior;
+use SWP\Bundle\CoreBundle\Model\ContentListInterface;
+use SWP\Bundle\CoreBundle\Model\ContentListItemInterface;
+use SWP\Bundle\CoreBundle\Widget\LiveblogWidgetHandler;
+use SWP\Bundle\TemplatesSystemBundle\Widget\TemplatingWidgetHandler;
+use SWP\Component\ContentList\Repository\ContentListRepositoryInterface;
+use SWP\Component\TemplatesSystem\Gimme\Model\WidgetModelInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Templating\EngineInterface;
+
+final class LiveblogWidgetHandlerSpec extends ObjectBehavior
+{
+    public function let(
+        WidgetModelInterface $widgetModel,
+        ContainerInterface $container
+    ) {
+        $widgetModel->getParameters()->willReturn(['url' => 'http://publisher.dev']);
+
+        $this->beConstructedWith($widgetModel, $container);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(LiveblogWidgetHandler::class);
+        $this->shouldHaveType(TemplatingWidgetHandler::class);
+    }
+
+    public function it_should_render(
+        ContainerInterface $container,
+        EngineInterface $templating,
+        Response $response
+    ) {
+        $container->get('templating')->willReturn($templating);
+        $templating->render('widgets/liveblog.html.twig', [
+            'url' => 'http://publisher.dev',
+        ])->willReturn($response);
+
+        $this->render()->shouldReturn($response);
+    }
+
+    public function it_should_render_with_custom_template(
+        ContentListRepositoryInterface $contentListRepository,
+        WidgetModelInterface $widgetModel,
+        ContainerInterface $container,
+        EngineInterface $templating,
+        ContentListInterface $contentList,
+        ContentListItemInterface $contentListItem,
+        Response $response
+    ) {
+        $widgetModel->getParameters()->willReturn([
+            'url' => 'http://publisher.dev',
+            'template_name' => 'custom.html.twig',
+        ]);
+
+        $this->beConstructedWith($widgetModel, $container);
+
+        $container->get('templating')->willReturn($templating);
+        $templating->render('widgets/custom.html.twig', [
+            'url' => 'http://publisher.dev',
+        ])->willReturn($response);
+
+        $this->render()->shouldReturn($response);
+    }
+}


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | no
| New feature?              | yes
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | yes
| Fixed tickets             | nope
| License                   | AGPLv3

TODO:
 * [x] test
 * [x] docs for `render_external_esi`
 * [x] update changelog
