### PR TITLE
[BC Break] make tenant sudbomain optional, and domain required, fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog references the relevant changes (bug and security fixes) done in 
 To get the diff for a specific change, go to https://github.com/superdesk/web-publisher/commit/XXX where XXX is the change hash
 
 * 1.1.x
+ * [BC Break] fix [#376] Make domainName field required in tenant create API
  * feature [#372] Add Liveblog widget, add external ESI renderer
  * feature [#368] Add Content List Loader
 

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -17,7 +17,7 @@
         <ini name="intl.default_locale" value="en" />
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="1000" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="1500" />
     </php>
 
     <testsuites>

--- a/src/SWP/Bundle/CoreBundle/Form/Type/TenantType.php
+++ b/src/SWP/Bundle/CoreBundle/Form/Type/TenantType.php
@@ -38,17 +38,17 @@ final class TenantType extends AbstractType
                 ],
             ])
             ->add('subdomain', TextType::class, [
-                'required' => true,
+                'required' => false,
                 'description' => 'Tenant subdomain',
                 'constraints' => [
-                    new NotBlank(),
                     new Length(['min' => 3]),
                 ],
             ])
             ->add('domainName', TextType::class, [
-                'required' => false,
+                'required' => true,
                 'description' => 'Tenant domain name',
                 'constraints' => [
+                    new NotBlank(),
                     new Length(['min' => 3]),
                 ],
             ])

--- a/src/SWP/Bundle/CoreBundle/Tests/Controller/TenantControllerTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Controller/TenantControllerTest.php
@@ -67,6 +67,7 @@ class TenantControllerTest extends WebTestCase
             'tenant' => [
                 'name' => 'Test Tenant',
                 'subdomain' => 'test',
+                'domainName' => 'localhost',
                 'themeName' => 'swp/test-theme',
                 'organization' => '123456',
             ],
@@ -74,7 +75,7 @@ class TenantControllerTest extends WebTestCase
 
         $this->assertEquals(201, $client->getResponse()->getStatusCode());
         $this->assertArraySubset(json_decode(
-            '{"id":4,"subdomain":"test","name":"Test Tenant","organization":{"id":1,"name":"Organization1","code":"123456"},"enabled":true,"themeName":"swp\/test-theme","domainName":null}', true
+            '{"id":4,"subdomain":"test","name":"Test Tenant","organization":{"id":1,"name":"Organization1","code":"123456"},"enabled":true,"themeName":"swp\/test-theme","domainName":"localhost"}', true
         ), json_decode(
             $client->getResponse()->getContent(),
             true
@@ -88,6 +89,7 @@ class TenantControllerTest extends WebTestCase
             'tenant' => [
                 'name' => 'Test Tenant',
                 'subdomain' => 'test',
+                'domainName' => 'localhost',
                 'themeName' => 'fake/theme-name',
             ],
         ]);
@@ -102,6 +104,7 @@ class TenantControllerTest extends WebTestCase
             'tenant' => [
                 'name' => 'Test Tenant',
                 'subdomain' => 'test',
+                'domainName' => 'localhost',
                 'themeName' => 'swp/test-theme',
             ],
         ]);
@@ -112,6 +115,7 @@ class TenantControllerTest extends WebTestCase
             'tenant' => [
                 'name' => 'Test Tenant',
                 'subdomain' => 'test',
+                'domainName' => 'localhost',
                 'themeName' => 'swp/test-theme',
             ],
         ]);
@@ -126,6 +130,7 @@ class TenantControllerTest extends WebTestCase
             'tenant' => [
                 'name' => 'Test Tenant',
                 'subdomain' => 'test',
+                'domainName' => 'localhost',
                 'themeName' => 'swp/test-theme',
             ],
         ]);
@@ -148,6 +153,7 @@ class TenantControllerTest extends WebTestCase
             'tenant' => [
                 'name' => 'Test Tenant',
                 'subdomain' => 'test',
+                'domainName' => 'localhost',
                 'themeName' => 'swp/test-theme',
             ],
         ]);

--- a/src/SWP/Bundle/CoreBundle/spec/Form/Type/TenantTypeSpec.php
+++ b/src/SWP/Bundle/CoreBundle/spec/Form/Type/TenantTypeSpec.php
@@ -57,10 +57,9 @@ class TenantTypeSpec extends ObjectBehavior
 
         $builder
             ->add('subdomain', TextType::class, [
-                'required' => true,
+                'required' => false,
                 'description' => 'Tenant subdomain',
                 'constraints' => [
-                    new NotBlank(),
                     new Length(['min' => 3]),
                 ],
             ])
@@ -69,9 +68,10 @@ class TenantTypeSpec extends ObjectBehavior
 
         $builder
             ->add('domainName', TextType::class, [
-                'required' => false,
+                'required' => true,
                 'description' => 'Tenant domain name',
                 'constraints' => [
+                    new NotBlank(),
                     new Length(['min' => 3]),
                 ],
             ])->willReturn($builder)


### PR DESCRIPTION
[BC Break] Change in create tenant API endpoint - tenant domainName is now required. 

| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | yes
| Deprecations?             | yes
| Tests pass?               | yes
| Changelog update required | yes
| Fixed tickets             | nope
| License                   | AGPLv3
