### PR TITLE
fixed index for tenant table

### DIFF
--- a/app/migrations/Version20170831132632.php
+++ b/app/migrations/Version20170831132632.php
@@ -18,6 +18,7 @@ class Version20170831132632 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
 
+        $this->addSql('DROP INDEX uniq_ec6095fe5e237e06');
         $this->addSql('DROP INDEX host_idx');
         $this->addSql('CREATE UNIQUE INDEX host_idx ON swp_tenant (domain_name, subdomain, deleted_at)');
     }
@@ -31,6 +32,7 @@ class Version20170831132632 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
 
         $this->addSql('DROP INDEX host_idx');
+        $this->addSql('CREATE UNIQUE INDEX uniq_ec6095fe5e237e06 ON swp_tenant (name)');
         $this->addSql('CREATE UNIQUE INDEX host_idx ON swp_tenant (domain_name, subdomain)');
     }
 }

--- a/app/migrations/Version20170831132632.php
+++ b/app/migrations/Version20170831132632.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SWP\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170831132632 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DROP INDEX host_idx');
+        $this->addSql('CREATE UNIQUE INDEX host_idx ON swp_tenant (domain_name, subdomain, deleted_at)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DROP INDEX host_idx');
+        $this->addSql('CREATE UNIQUE INDEX host_idx ON swp_tenant (domain_name, subdomain)');
+    }
+}

--- a/src/SWP/Bundle/MultiTenancyBundle/Resources/config/doctrine-orm/Tenant.orm.yml
+++ b/src/SWP/Bundle/MultiTenancyBundle/Resources/config/doctrine-orm/Tenant.orm.yml
@@ -17,7 +17,6 @@ SWP\Component\MultiTenancy\Model\Tenant:
         name:
             type: string
             length: 255
-            unique: true
         subdomain:
             type: string
             length: 255

--- a/src/SWP/Bundle/MultiTenancyBundle/Resources/config/doctrine-orm/Tenant.orm.yml
+++ b/src/SWP/Bundle/MultiTenancyBundle/Resources/config/doctrine-orm/Tenant.orm.yml
@@ -53,4 +53,4 @@ SWP\Component\MultiTenancy\Model\Tenant:
                 referencedColumnName: id
     uniqueConstraints:
         host_idx:
-            columns: [ domain_name, subdomain ]
+            columns: [ domain_name, subdomain, deleted_at ]


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | no
| License                   | AGPLv3

When a tenant with, for example, name "test" is removed, and you want to create another tenant with the same name under the same organization, API throws 500 error because it still detects that tenant with subdomain "test" exists in the database even if it was flagged as deleted.

The deleted tenant should not be taken into consideration, instead, a new tenant with the same subdomain should be created because the previous one was deleted and the deleted tenants can not be re-activated.

Tenant's name should not be unique because it is just a name.