### PR TITLE
Generate route's slug based on route's name if not provided by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog references the relevant changes (bug and security fixes) done in 
 To get the diff for a specific change, go to https://github.com/superdesk/web-publisher/commit/XXX where XXX is the change hash
 
 * 1.1.x
+ * feature [#446] Generate route's slug based on route's name if not provided by default
  * feature [#445] Implemented a list of optional values to theme's settings
  * feature [#444] Added an to get a single route by name and slug 
  * feature [#441] Added an option to list articles' authors in Twig templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This changelog references the relevant changes (bug and security fixes) done in 
 To get the diff for a specific change, go to https://github.com/superdesk/web-publisher/commit/XXX where XXX is the change hash
 
 * 1.1.x
- * feature [#446] Generate route's slug based on route's name if not provided by default
+ * feature [#447] Generate route's slug based on route's name if not provided by default
  * feature [#445] Implemented a list of optional values to theme's settings
  * feature [#444] Added an to get a single route by name and slug 
  * feature [#441] Added an option to list articles' authors in Twig templates

--- a/app/migrations/Version20180223095718.php
+++ b/app/migrations/Version20180223095718.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SWP\Migrations;
+
+use Behat\Transliterator\Transliterator;
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use SWP\Bundle\ContentBundle\Model\RouteInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180223095718 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @param ContainerInterface|null $container
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+
+        $entityManager = $this->container->get('doctrine.orm.default_entity_manager');
+        $routeRepository = $this->container->get('swp.repository.route');
+
+        /** @var RouteInterface $route */
+        foreach ($routeRepository->findBy(['slug' => null]) as $route) {
+            $route->setSlug(Transliterator::transliterate($route->getName()));
+        }
+
+        $entityManager->flush();
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+
+        $entityManager = $this->container->get('doctrine.orm.default_entity_manager');
+        $routeRepository = $this->container->get('swp.repository.route');
+
+        /** @var RouteInterface $route */
+        foreach ($routeRepository->findAll() as $route) {
+            if ($route->getSlug() === Transliterator::transliterate($route->getName())) {
+                $route->setSlug(null);
+            }
+        }
+
+        $entityManager->flush();
+    }
+}

--- a/app/migrations/Version20180223095718.php
+++ b/app/migrations/Version20180223095718.php
@@ -63,7 +63,7 @@ class Version20180223095718 extends AbstractMigration implements ContainerAwareI
         $routes = $query->getArrayResult();
 
         foreach ($routes as $route) {
-            if ($route['slug'] === Transliterator::transliterate($route['slug'])) {
+            if ($route['slug'] === Transliterator::transliterate($route['name'])) {
                 $qb = $entityManager->createQueryBuilder();
                 $query = $qb->update(RouteInterface::class, 'r')
                     ->set('r.slug', '?1')

--- a/app/migrations/Version20180223095718.php
+++ b/app/migrations/Version20180223095718.php
@@ -36,7 +36,7 @@ class Version20180223095718 extends AbstractMigration implements ContainerAwareI
 
         $entityManager = $this->container->get('doctrine.orm.default_entity_manager');
         $query = $entityManager
-            ->createQuery('SELECT r.id, r.name, r.slug FROM SWP\Bundle\CoreBundle\Model\Route r  WHERE r.slug IS NULL');
+            ->createQuery('SELECT r.id, r.name FROM SWP\Bundle\CoreBundle\Model\Route r  WHERE r.slug IS NULL');
         $routes = $query->getArrayResult();
 
         foreach ($routes as $route) {

--- a/app/migrations/Version20180223095718.php
+++ b/app/migrations/Version20180223095718.php
@@ -36,7 +36,7 @@ class Version20180223095718 extends AbstractMigration implements ContainerAwareI
 
         $entityManager = $this->container->get('doctrine.orm.default_entity_manager');
         $query = $entityManager
-            ->createQuery('SELECT r.id, r.name, r.slug FROM SWP\Bundle\CoreBundle\Model\Route r');
+            ->createQuery('SELECT r.id, r.name, r.slug FROM SWP\Bundle\CoreBundle\Model\Route r  WHERE r.slug IS NULL');
         $routes = $query->getArrayResult();
 
         foreach ($routes as $route) {

--- a/app/migrations/Version20180223095718.php
+++ b/app/migrations/Version20180223095718.php
@@ -36,16 +36,16 @@ class Version20180223095718 extends AbstractMigration implements ContainerAwareI
 
         $entityManager = $this->container->get('doctrine.orm.default_entity_manager');
         $query = $entityManager
-            ->createQuery('SELECT r FROM SWP\Bundle\CoreBundle\Model\Route r WHERE r.slug IS NULL');
-        $routes = $query->getResult();
+            ->createQuery('SELECT r.id, r.name, r.slug FROM SWP\Bundle\CoreBundle\Model\Route r');
+        $routes = $query->getArrayResult();
 
         foreach ($routes as $route) {
             $qb = $entityManager->createQueryBuilder();
             $query = $qb->update(RouteInterface::class, 'r')
                 ->set('r.slug', '?1')
                 ->where('r.id = ?2')
-                ->setParameter(1, Transliterator::transliterate($route->getName()))
-                ->setParameter(2, $route->getId())
+                ->setParameter(1, Transliterator::transliterate($route['name']))
+                ->setParameter(2, $route['id'])
                 ->getQuery();
 
             $query->execute();
@@ -59,17 +59,17 @@ class Version20180223095718 extends AbstractMigration implements ContainerAwareI
 
         $entityManager = $this->container->get('doctrine.orm.default_entity_manager');
         $query = $entityManager
-            ->createQuery('SELECT r FROM SWP\Bundle\CoreBundle\Model\Route r');
-        $routes = $query->getResult();
+            ->createQuery('SELECT r.id, r.name, r.slug FROM SWP\Bundle\CoreBundle\Model\Route r');
+        $routes = $query->getArrayResult();
 
         foreach ($routes as $route) {
-            if ($route->getSlug() === Transliterator::transliterate($route->getName())) {
+            if ($route['slug'] === Transliterator::transliterate($route['slug'])) {
                 $qb = $entityManager->createQueryBuilder();
                 $query = $qb->update(RouteInterface::class, 'r')
                     ->set('r.slug', '?1')
                     ->where('r.id = ?2')
                     ->setParameter(1, null)
-                    ->setParameter(2, $route->getId())
+                    ->setParameter(2, $route['id'])
                     ->getQuery();
 
                 $query->execute();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Superdesk Publisher'
-copyright = u'2016, Sourcefabric z.ú'
+copyright = u'2018, Sourcefabric z.ú'
 author = u'Sourcefabric z.ú.'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/manual/templates_system/routes.rst
+++ b/docs/manual/templates_system/routes.rst
@@ -2,16 +2,20 @@ Handling Routes
 ===============
 
 Listing a Single Route
----------------------------------
+----------------------
 
 Usage:
 
 .. code-block:: twig
 
     <ul>
-    {% gimme route with { slug: 'test-route', name: 'Test Route'} %}
+    {% gimme route with { parent: 5, slug: 'test-route', name: 'Test Route'} %}
         <li>{{ route.name }}</li> <!-- Route's name -->
         <li>{{ route.slug }}</li> <!-- Route's slug -->
         <li>{{ url(route) }}</li> <!-- Route's url -->
     {% endgimme %}
     </ul>
+
+- ``parent`` - an id of parent route
+- ``slug`` - route's slug
+- ``name`` - route's name

--- a/features/routes/management.feature
+++ b/features/routes/management.feature
@@ -45,5 +45,5 @@ Feature: Manage Routes
     """
     Then the response status code should be 201
     And the JSON node name should be equal to "Simple test route number 2"
-    And the JSON node slug should be null
+    And the JSON node slug should be equal to "simple-test-route-number-2"
     And the JSON node staticPrefix should be equal to "/simple-test-route-number-2"

--- a/features/twig/listing_route_by_slug.feature
+++ b/features/twig/listing_route_by_slug.feature
@@ -29,7 +29,6 @@ Feature: Listing single route by slug or name
       {
         "route": {
           "name": "Test route",
-          "slug": "test-route",
           "type": "content",
           "parent": 7
         }

--- a/features/twig/listing_route_by_slug_and_parent.feature
+++ b/features/twig/listing_route_by_slug_and_parent.feature
@@ -1,0 +1,59 @@
+Feature: Listing single route by slug and parent
+  In case there are routes with the same slugs but under different parents
+  As a HTTP Client
+  I want to be able to render it by providing slug and parent to display the proper route
+
+  Scenario: Listing single route's url by slug and parent
+    Given I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/api/v1/content/routes/" with body:
+     """
+      {
+        "route": {
+          "name": "Politics",
+          "type": "collection",
+          "templateName": "route_by_slug_and_parent.html.twig"
+        }
+      }
+    """
+    Then the response status code should be 201
+    And the JSON node name should be equal to "Politics"
+    And the JSON node slug should be equal to "politics"
+    And the JSON node staticPrefix should be equal to "/politics"
+    And the JSON node id should be equal to "7"
+    And I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/api/v1/content/routes/" with body:
+     """
+      {
+        "route": {
+          "name": "Test route",
+          "type": "content",
+          "parent": 7
+        }
+      }
+    """
+    Then the response status code should be 201
+    And the JSON node name should be equal to "Test route"
+    And the JSON node parent should be equal to "7"
+    And the JSON node slug should be equal to "test-route"
+    And the JSON node staticPrefix should be equal to "/politics/test-route"
+    And I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/api/v1/content/routes/" with body:
+     """
+      {
+        "route": {
+          "name": "Test route 2",
+          "type": "content",
+          "slug": "test-route"
+        }
+      }
+    """
+    Then the response status code should be 201
+    And the JSON node name should be equal to "Test route 2"
+    And the JSON node slug should be equal to "test-route"
+    And the JSON node staticPrefix should be equal to "/test-route"
+    When I go to "/politics"
+    Then the response status code should be 200
+    And I should see "http://localhost/politics/test-route"

--- a/src/SWP/Bundle/ContentBundle/Loader/RouteLoader.php
+++ b/src/SWP/Bundle/ContentBundle/Loader/RouteLoader.php
@@ -39,6 +39,11 @@ class RouteLoader implements LoaderInterface
     protected $routeRepository;
 
     /**
+     * @var array
+     */
+    protected $supportedParameters = ['name', 'slug', 'parent'];
+
+    /**
      * RouteLoader constructor.
      *
      * @param MetaFactoryInterface     $metaFactory
@@ -63,15 +68,16 @@ class RouteLoader implements LoaderInterface
             }
 
             $criteria = new Criteria();
-            if (array_key_exists('name', $parameters) && \is_string($parameters['name'])) {
-                $criteria->set('name', $parameters['name']);
+            foreach ($this->supportedParameters as $supportedParameter) {
+                if (array_key_exists($supportedParameter, $parameters)) {
+                    $criteria->set($supportedParameter, $parameters[$supportedParameter]);
+                }
             }
 
-            if (array_key_exists('slug', $parameters) && \is_string($parameters['slug'])) {
-                $criteria->set('slug', $parameters['slug']);
-            }
-
-            $route = $this->routeRepository->getQueryByCriteria($criteria, [], 'r')->getQuery()->getOneOrNullResult();
+            $route = $this->routeRepository->getQueryByCriteria($criteria, [], 'r')
+                ->setMaxResults(1)
+                ->getQuery()
+                ->getOneOrNullResult();
         }
 
         if (null !== $route) {

--- a/src/SWP/Bundle/ContentBundle/Model/RouteInterface.php
+++ b/src/SWP/Bundle/ContentBundle/Model/RouteInterface.php
@@ -127,9 +127,9 @@ interface RouteInterface extends TreeAwareRouteInterface, PersistableInterface, 
     /**
      * Slug is used for static prefix generation.
      *
-     * @param string $slug
+     * @param string|null $slug
      */
-    public function setSlug(string $slug): void;
+    public function setSlug(?string $slug): void;
 
     /**
      * @return int

--- a/src/SWP/Bundle/ContentBundle/Model/RouteTrait.php
+++ b/src/SWP/Bundle/ContentBundle/Model/RouteTrait.php
@@ -90,9 +90,9 @@ trait RouteTrait
     /**
      * Slug is used for static prefix generation.
      *
-     * @param string $slug
+     * @param string|null $slug
      */
-    public function setSlug(string $slug): void
+    public function setSlug(?string $slug): void
     {
         $this->slug = $slug;
     }

--- a/src/SWP/Bundle/ContentBundle/Service/RouteService.php
+++ b/src/SWP/Bundle/ContentBundle/Service/RouteService.php
@@ -75,6 +75,10 @@ class RouteService implements RouteServiceInterface
      */
     public function fillRoute(RouteInterface $route)
     {
+        if (null === $route->getSlug()) {
+            $route->setSlug(Transliterator::urlize($route->getName()));
+        }
+
         switch ($route->getType()) {
             case RouteInterface::TYPE_CONTENT:
                 $route->setVariablePattern(null);
@@ -104,9 +108,7 @@ class RouteService implements RouteServiceInterface
     protected function generatePath(RouteInterface $route)
     {
         $slug = $route->getSlug();
-        if (null === $slug) {
-            $slug = Transliterator::urlize($route->getName());
-        }
+
         if (null === $parent = $route->getParent()) {
             return '/'.$slug;
         }

--- a/src/SWP/Bundle/ContentBundle/Tests/Functional/Controller/RouteControllerTest.php
+++ b/src/SWP/Bundle/ContentBundle/Tests/Functional/Controller/RouteControllerTest.php
@@ -47,7 +47,7 @@ class RouteControllerTest extends WebTestCase
         ]);
 
         self::assertEquals(201, $client->getResponse()->getStatusCode());
-        self::assertEquals(json_decode('{"id":1,"content":null,"staticPrefix":"\/simple-test-route","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":0,"name":"simple-test-route","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}}, "slug":null}', true), json_decode($client->getResponse()->getContent(), true));
+        self::assertEquals(json_decode('{"id":1,"content":null,"staticPrefix":"\/simple-test-route","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":0,"name":"simple-test-route","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}}, "slug":"simple-test-route"}', true), json_decode($client->getResponse()->getContent(), true));
     }
 
     public function testCreateContentRoutesApi()
@@ -131,7 +131,7 @@ class RouteControllerTest extends WebTestCase
         ]);
 
         self::assertEquals(200, $client->getResponse()->getStatusCode());
-        self::assertArraySubset(json_decode('{"content":{"title":"Test content article","body":"Test article content","slug":"test-content-article","status":"published","route":{"content":null,"staticPrefix":null,"variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"news","position":0},"templateName":null,"publishStartDate":null,"publishEndDate":null,"isPublishable":true,"metadata":null,"media":[],"lead":null},"staticPrefix":"\/simple-edited-test-route","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":50,"name":"simple-edited-test-route","position":1}', true), json_decode($client->getResponse()->getContent(), true));
+        self::assertArraySubset(json_decode('{"content":{"title":"Test content article","body":"Test article content","slug":"test-content-article","status":"published","route":{"content":null,"staticPrefix":null,"variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"news","position":0},"templateName":null,"publishStartDate":null,"publishEndDate":null,"isPublishable":true,"metadata":null,"media":[],"lead":null},"staticPrefix":"\/simple-test-route","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":50,"name":"simple-edited-test-route","position":1}', true), json_decode($client->getResponse()->getContent(), true));
 
         $client->request('DELETE', $this->router->generate('swp_api_content_delete_routes', ['id' => $content['id']]));
         self::assertEquals(409, $client->getResponse()->getStatusCode());
@@ -265,7 +265,7 @@ class RouteControllerTest extends WebTestCase
 
         $content = json_decode($client->getResponse()->getContent(), true);
 
-        self::assertEquals(json_decode('{"page":1,"limit":10,"pages":1,"total":2,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":1,"content":null,"staticPrefix":"\/route1","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"route1","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}},"slug":null},{"id":2,"content":null,"staticPrefix":"\/route2","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":2,"name":"route2","position":1,"root":2,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"}},"slug":null}]}}', true), $content);
+        self::assertEquals(json_decode('{"page":1,"limit":10,"pages":1,"total":2,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":1,"content":null,"staticPrefix":"\/route1","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"route1","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}},"slug":"route1"},{"id":2,"content":null,"staticPrefix":"\/route2","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":2,"name":"route2","position":1,"root":2,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"}},"slug":"route2"}]}}', true), $content);
 
         $client->request('GET', $this->router->generate('swp_api_content_create_routes', [
             'type' => 'content',
@@ -274,7 +274,7 @@ class RouteControllerTest extends WebTestCase
         self::assertEquals(200, $client->getResponse()->getStatusCode());
         $content = json_decode($client->getResponse()->getContent(), true);
 
-        self::assertEquals(json_decode('{"page":1,"limit":10,"pages":1,"total":1,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":1,"content":null,"staticPrefix":"\/route1","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"route1","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}},"slug":null}]}}', true), $content);
+        self::assertEquals(json_decode('{"page":1,"limit":10,"pages":1,"total":1,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":1,"content":null,"staticPrefix":"\/route1","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"route1","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}},"slug":"route1"}]}}', true), $content);
 
         $client->request('GET', $this->router->generate('swp_api_content_create_routes', [
             'type' => 'collection',
@@ -283,7 +283,7 @@ class RouteControllerTest extends WebTestCase
         self::assertEquals(200, $client->getResponse()->getStatusCode());
         $content = json_decode($client->getResponse()->getContent(), true);
 
-        self::assertEquals(json_decode('{"page":1,"limit":10,"pages":1,"total":1,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":2,"content":null,"staticPrefix":"\/route2","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":2,"name":"route2","position":1,"root":2,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"}},"slug":null}]}}', true), $content);
+        self::assertEquals(json_decode('{"page":1,"limit":10,"pages":1,"total":1,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":2,"content":null,"staticPrefix":"\/route2","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":2,"name":"route2","position":1,"root":2,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"}},"slug":"route2"}]}}', true), $content);
 
         $client->request('GET', $this->router->generate('swp_api_content_create_routes', [
             'type' => 'fake',

--- a/src/SWP/Bundle/ContentBundle/Tests/Functional/app/Resources/fixtures/separate_article.yml
+++ b/src/SWP/Bundle/ContentBundle/Tests/Functional/app/Resources/fixtures/separate_article.yml
@@ -12,7 +12,7 @@ SWP\Bundle\ContentBundle\Model\Article:
         locale: "en"
         status: "published"
         publishable: true
-        code: "<uuid()"
+        code: "<uuid()>"
         publishedAt: "<date()>"
     article2:
         title: "Test content article"
@@ -21,5 +21,5 @@ SWP\Bundle\ContentBundle\Model\Article:
         locale: "en"
         status: "published"
         publishable: true
-        code: "<uuid()"
+        code: "<uuid()>"
         publishedAt: "<date()>"

--- a/src/SWP/Bundle/ContentBundle/spec/Service/RouteServiceSpec.php
+++ b/src/SWP/Bundle/ContentBundle/spec/Service/RouteServiceSpec.php
@@ -52,7 +52,7 @@ class RouteServiceSpec extends ObjectBehavior
     ) {
         $route->getType()->willReturn(RouteInterface::TYPE_CONTENT);
         $route->getName()->willReturn('test-name');
-        $route->getSlug()->willReturn(null);
+        $route->getSlug()->willReturn('test-name');
         $route->getTemplateName()->willReturn('index.html.twig');
         $route->getParent()->willReturn($parent);
 
@@ -80,7 +80,7 @@ class RouteServiceSpec extends ObjectBehavior
     ) {
         $route->getType()->willReturn(RouteInterface::TYPE_CONTENT);
         $route->getName()->willReturn('Test Name');
-        $route->getSlug()->willReturn('test-name');
+        $route->getSlug()->willReturn('test-name-2');
         $route->getTemplateName()->willReturn('index.html.twig');
         $route->getParent()->willReturn($parent);
 
@@ -91,7 +91,7 @@ class RouteServiceSpec extends ObjectBehavior
 
         $route->setVariablePattern(null)->shouldBeCalled();
         $route->setRequirements([])->shouldBeCalled();
-        $route->setStaticPrefix('/test-name')->shouldBeCalled();
+        $route->setStaticPrefix('/test-name-2')->shouldBeCalled();
 
         $eventDispatcher->dispatch(
             RouteEvents::POST_CREATE,
@@ -108,7 +108,7 @@ class RouteServiceSpec extends ObjectBehavior
     ) {
         $route->getType()->willReturn(RouteInterface::TYPE_CONTENT);
         $route->getName()->willReturn('Test Name');
-        $route->getSlug()->willReturn(null);
+        $route->getSlug()->willReturn('test-name');
         $route->getTemplateName()->willReturn('index.html.twig');
         $route->getParent()->willReturn($parent);
 
@@ -136,7 +136,7 @@ class RouteServiceSpec extends ObjectBehavior
     ) {
         $route->getType()->willReturn(RouteInterface::TYPE_COLLECTION);
         $route->getName()->willReturn('test-name');
-        $route->getSlug()->willReturn(null);
+        $route->getSlug()->willReturn('test-name');
         $route->getTemplateName()->willReturn('index.html.twig');
         $route->getParent()->willReturn($parent);
 
@@ -166,7 +166,7 @@ class RouteServiceSpec extends ObjectBehavior
         $route->getType()->willReturn(RouteInterface::TYPE_COLLECTION);
         $route->getParent()->willReturn($parent);
         $route->getName()->willReturn('test-name');
-        $route->getSlug()->willReturn(null);
+        $route->getSlug()->willReturn('test-name');
 
         $eventDispatcher->dispatch(
             RouteEvents::PRE_UPDATE,

--- a/src/SWP/Bundle/CoreBundle/Tests/Controller/ContentControllerTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Controller/ContentControllerTest.php
@@ -116,7 +116,7 @@ class ContentControllerTest extends WebTestCase
 
         $client = static::createClient();
 
-        $crawler = $client->request('GET', '/collection-content');
+        $client->request('GET', '/collection-content');
         self::assertEquals(200, $client->getResponse()->getStatusCode());
         self::assertContains('This is default "category.html.twig" template file.', $client->getResponse()->getContent());
     }
@@ -138,7 +138,7 @@ class ContentControllerTest extends WebTestCase
         ]);
 
         $this->assertEquals(201, $client->getResponse()->getStatusCode());
-        $this->assertEquals('{"id":3,"content":null,"staticPrefix":"\/simple-test-route","variablePattern":null,"root":3,"parent":null,"children":[],"level":0,"templateName":"test.html.twig","articlesTemplateName":null,"type":"content","cacheTimeInSeconds":0,"name":"simple-test-route","slug":null,"position":1,"articlesCount":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/3"}}}', $client->getResponse()->getContent());
+        $this->assertEquals('{"id":3,"content":null,"staticPrefix":"\/simple-test-route","variablePattern":null,"root":3,"parent":null,"children":[],"level":0,"templateName":"test.html.twig","articlesTemplateName":null,"type":"content","cacheTimeInSeconds":0,"name":"simple-test-route","slug":"simple-test-route","position":1,"articlesCount":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/3"}}}', $client->getResponse()->getContent());
 
         $crawler = $client->request('GET', '/simple-test-route');
         $this->assertEquals(200, $client->getResponse()->getStatusCode());

--- a/src/SWP/Bundle/CoreBundle/Tests/Fixtures/themes/123abc/theme_test/views/route_by_slug_and_parent.html.twig
+++ b/src/SWP/Bundle/CoreBundle/Tests/Fixtures/themes/123abc/theme_test/views/route_by_slug_and_parent.html.twig
@@ -1,0 +1,3 @@
+{% gimme route with {parent: 7, slug: 'test route'|slugify} %}
+    {{ url(route) }}
+{% endgimme %}


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | yes
| Fixed tickets             | SWP-1061
| License                   | AGPLv3

TODO:
 - [x] - add migration to generate slug from name if existing routes' slug is null