### PR TITLE
Missing setting in theme.json should not break pages in prod

### DIFF
--- a/docs/manual/themes/theme_settings.rst
+++ b/docs/manual/themes/theme_settings.rst
@@ -78,7 +78,8 @@ How to display current theme's settings in templates?
     {# app/themes/<tenant_code>/<theme_name>/views/index.html.twig #}
     {{ themeSetting('primary_font_family') }} # will print "Roboto"
 
-If the theme's setting doesn't exists an exception will be thrown with a proper message that it does not exist.
+In development environment, ff the theme's setting doesn't exists an exception will be thrown with a proper message that it does not exist.
+In production environment no exception will be thrown, the page will render normally.
 
 
 How to display current theme's settings using API?

--- a/docs/manual/themes/theme_settings.rst
+++ b/docs/manual/themes/theme_settings.rst
@@ -78,7 +78,7 @@ How to display current theme's settings in templates?
     {# app/themes/<tenant_code>/<theme_name>/views/index.html.twig #}
     {{ themeSetting('primary_font_family') }} # will print "Roboto"
 
-In development environment, ff the theme's setting doesn't exists an exception will be thrown with a proper message that it does not exist.
+In development environment, if the theme's setting doesn't exists an exception will be thrown with a proper message that it does not exist.
 In production environment no exception will be thrown, the page will render normally.
 
 

--- a/src/SWP/Bundle/CoreBundle/Resources/config/twig.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/twig.yml
@@ -48,5 +48,6 @@ services:
             - '@swp_core.provider.theme_logo'
             - '@swp_multi_tenancy.tenant_context'
             - '@swp_settings.manager.settings'
+            - '%kernel.environment%'
         tags:
             - { name: twig.extension }

--- a/src/SWP/Bundle/CoreBundle/Twig/ThemeExtension.php
+++ b/src/SWP/Bundle/CoreBundle/Twig/ThemeExtension.php
@@ -42,20 +42,28 @@ final class ThemeExtension extends AbstractExtension
     private $settingsManager;
 
     /**
+     * @var string
+     */
+    private $env;
+
+    /**
      * ThemeExtension constructor.
      *
      * @param ThemeLogoProviderInterface $themeLogoProvider
      * @param TenantContextInterface     $tenantContext
      * @param SettingsManagerInterface   $settingsManager
+     * @param string                     $env
      */
     public function __construct(
         ThemeLogoProviderInterface $themeLogoProvider,
         TenantContextInterface $tenantContext,
-        SettingsManagerInterface $settingsManager
+        SettingsManagerInterface $settingsManager,
+        string $env
     ) {
         $this->themeLogoProvider = $themeLogoProvider;
         $this->tenantContext = $tenantContext;
         $this->settingsManager = $settingsManager;
+        $this->env = $env;
     }
 
     /**
@@ -91,6 +99,19 @@ final class ThemeExtension extends AbstractExtension
      * @return string
      */
     public function getThemeSetting(string $setting): string
+    {
+        if ('dev' === $this->env) {
+            return $this->getSetting($setting);
+        }
+
+        try {
+            return $this->getSetting($setting);
+        } catch (\Exception $e) {
+            return '';
+        }
+    }
+
+    private function getSetting(string $setting): string
     {
         /** @var TenantInterface $tenant */
         $tenant = $this->tenantContext->getTenant();

--- a/src/SWP/Bundle/CoreBundle/Twig/ThemeExtension.php
+++ b/src/SWP/Bundle/CoreBundle/Twig/ThemeExtension.php
@@ -97,17 +97,19 @@ final class ThemeExtension extends AbstractExtension
      * @param string $setting
      *
      * @return string
+     *
+     * @throws \Exception
      */
     public function getThemeSetting(string $setting): string
     {
-        if ('dev' === $this->env) {
-            return $this->getSetting($setting);
-        }
-
         try {
             return $this->getSetting($setting);
         } catch (\Exception $e) {
-            return '';
+            if ('dev' !== $this->env) {
+                return '';
+            }
+
+            throw $e;
         }
     }
 

--- a/src/SWP/Bundle/CoreBundle/Twig/ThemeExtension.php
+++ b/src/SWP/Bundle/CoreBundle/Twig/ThemeExtension.php
@@ -105,7 +105,7 @@ final class ThemeExtension extends AbstractExtension
         try {
             return $this->getSetting($setting);
         } catch (\Exception $e) {
-            if ('dev' !== $this->env) {
+            if ('prod' === $this->env) {
                 return '';
             }
 


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | no
| Fixed tickets             | SWP-1102
| License                   | AGPLv3
