### PR TITLE
don't create 'theme' dir when installing assets, absolute dirs

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -77,6 +77,7 @@ services:
             - '@twig'
             - '%swp.theme.configuration.default_directory%'
             - '@sylius.theme.asset.assets_installer'
+            - '%kernel.project_dir%/web'
 
     swp_core.generator.theme.fake_article:
         class: SWP\Bundle\CoreBundle\Theme\Generator\FakeArticlesGenerator

--- a/src/SWP/Bundle/CoreBundle/Theme/Asset/AssetsInstaller.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Asset/AssetsInstaller.php
@@ -84,9 +84,10 @@ final class AssetsInstaller implements AssetsInstallerInterface
      */
     public function installAssets($targetDir, $symlinkMask)
     {
-        $targetDir = rtrim($targetDir, '/').'/theme/';
+        $targetDir = rtrim($targetDir, '/');
         $this->filesystem->mkdir($targetDir);
         $this->themeRepository->reloadThemes();
+        $targetDir .= '/theme/';
         $this->installGlobalAssets($targetDir, $symlinkMask);
 
         $effectiveSymlinkMask = $symlinkMask;

--- a/src/SWP/Bundle/CoreBundle/Theme/Installer/TenantAwareThemeInstaller.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Installer/TenantAwareThemeInstaller.php
@@ -29,8 +29,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 final class TenantAwareThemeInstaller implements ThemeInstallerInterface
 {
-    public const TRAGET_DIR = 'web';
-
     /**
      * @var TenantContextInterface
      */
@@ -57,25 +55,34 @@ final class TenantAwareThemeInstaller implements ThemeInstallerInterface
     private $assetsInstaller;
 
     /**
+     * @var string
+     */
+    private $assetsDir;
+
+    /**
      * TenantAwareThemeInstaller constructor.
      *
-     * @param TenantContextInterface $tenantContext
-     * @param ThemeLoaderInterface   $themeLoader
-     * @param \Twig_Environment      $twig
-     * @param string                 $baseDir
+     * @param TenantContextInterface   $tenantContext
+     * @param ThemeLoaderInterface     $themeLoader
+     * @param \Twig_Environment        $twig
+     * @param string                   $baseDir
+     * @param AssetsInstallerInterface $assetsInstaller
+     * @param string                   $assetsDir
      */
     public function __construct(
         TenantContextInterface $tenantContext,
         ThemeLoaderInterface $themeLoader,
         \Twig_Environment $twig,
         string $baseDir,
-        AssetsInstallerInterface $assetsInstaller
+        AssetsInstallerInterface $assetsInstaller,
+        string $assetsDir
     ) {
         $this->tenantContext = $tenantContext;
         $this->themeLoader = $themeLoader;
         $this->twig = $twig;
         $this->baseDir = $baseDir;
         $this->assetsInstaller = $assetsInstaller;
+        $this->assetsDir = $assetsDir;
     }
 
     /**
@@ -113,7 +120,7 @@ final class TenantAwareThemeInstaller implements ThemeInstallerInterface
             $filesystem->remove($cache->generateCacheDir());
         }
 
-        $this->assetsInstaller->installAssets(self::TRAGET_DIR, AssetsInstallerInterface::HARD_COPY);
+        $this->assetsInstaller->installAssets($this->assetsDir, AssetsInstallerInterface::HARD_COPY);
 
         return $theme;
     }


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | no
| License                   | AGPLv3

- don't create 'theme' dir when installing assets, 
- make theme assets path absolute