### PR TITLE
[fix] use X_FORWARDED_HOST when exists as server name in sub requests

### DIFF
--- a/src/SWP/Bundle/ContentBundle/EventListener/LinkRequestListener.php
+++ b/src/SWP/Bundle/ContentBundle/EventListener/LinkRequestListener.php
@@ -111,6 +111,12 @@ class LinkRequestListener
 
             $stubRequest->attributes->replace($route);
             $stubRequest->server = $event->getRequest()->server;
+            $stubRequest::setTrustedProxies(['192.0.0.1', '10.0.0.0/8', $event->getRequest()->server->get('REMOTE_ADDR')], Request::HEADER_X_FORWARDED_ALL);
+            // Keep server name in sync with forwarded host
+            if ($stubRequest->isFromTrustedProxy() && $stubRequest->server->has('HTTP_X_FORWARDED_HOST')) {
+                $stubRequest->server->set('SERVER_NAME', $stubRequest->server->has('HTTP_X_FORWARDED_HOST'));
+            }
+
             if (false === $controller = $this->resolver->getController($stubRequest)) {
                 continue;
             }

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -24,9 +24,9 @@ Debug::enable();
 
 $kernel = new AppKernel('dev', true);
 
-Request::enableHttpMethodParameterOverride();
-Request::setTrustedProxies(['192.0.0.1', '10.0.0.0/8'], Request::HEADER_X_FORWARDED_ALL);
 $request = Request::createFromGlobals();
+Request::enableHttpMethodParameterOverride();
+Request::setTrustedProxies(['192.0.0.1', '10.0.0.0/8', $request->server->get('REMOTE_ADDR')], Request::HEADER_X_FORWARDED_ALL);
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required   no
| Fixed tickets             | 
| License                   | AGPLv3
