### PR TITLE
[improvement] on route remove unpublish articles (status new) and package (status usable)

### DIFF
--- a/src/SWP/Bundle/ContentBundle/EventListener/RouteRemoveListener.php
+++ b/src/SWP/Bundle/ContentBundle/EventListener/RouteRemoveListener.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Content Bundle.
+ *
+ * Copyright 2018 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2018 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\ContentBundle\EventListener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use SWP\Bundle\ContentBundle\Event\ArticleEvent;
+use SWP\Bundle\ContentBundle\Event\RouteEvent;
+use SWP\Bundle\ContentBundle\Model\Article;
+use SWP\Bundle\ContentBundle\Model\ArticleInterface;
+
+final class RouteRemoveListener
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $manager;
+
+    /**
+     * RouteRemoveListener constructor.
+     *
+     * @param EntityManagerInterface $manager
+     */
+    public function __construct(EntityManagerInterface $manager)
+    {
+        $this->manager = $manager;
+    }
+
+    /**
+     * @param ArticleEvent $event
+     */
+    public function onDelete(RouteEvent $event)
+    {
+        $route = $event->getRoute();
+        $queryBuilder = $this->manager->createQueryBuilder();
+        $queryBuilder->update(Article::class, 'a')
+            ->set('a.status', $queryBuilder->expr()->literal(ArticleInterface::STATUS_NEW))
+            ->where('a.route = :route')
+            ->setParameter('route', $route->getId())
+            ->getQuery()
+            ->execute();
+    }
+}

--- a/src/SWP/Bundle/ContentBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/services.yml
@@ -176,6 +176,13 @@ services:
             - { name: kernel.event_listener, event: swp.article.unpublish, method: unpublish }
             - { name: kernel.event_listener, event: swp.article.canceled, method: cancel }
 
+    swp_content_bundle.listener.route_remove:
+        class: SWP\Bundle\ContentBundle\EventListener\RouteRemoveListener
+        arguments:
+            - '@doctrine.orm.entity_manager'
+        tags:
+            - { name: kernel.event_listener, event: swp.route.pre_delete, method: onDelete }
+
     swp.adder.article_source:
         class: SWP\Bundle\ContentBundle\Service\ArticleSourcesAdder
         arguments:

--- a/src/SWP/Bundle/ContentBundle/RouteEvents.php
+++ b/src/SWP/Bundle/ContentBundle/RouteEvents.php
@@ -62,4 +62,27 @@ class RouteEvents
      * @var string
      */
     const POST_CREATE = 'swp.route.post_create';
+
+    /**
+     * The PRE_DELETE event occurs before the route is deleted.
+     *
+     * This event allows you to modify route (and it's articles) before after it will be deleted.
+     *
+     * @Event("SWP\Bundle\ContentBundle\Event\RouteEvent")
+     *
+     * @var string
+     */
+    const PRE_DELETE = 'swp.route.pre_delete';
+
+    /**
+     * The POST_CREATE event occurs at the very ending of route
+     * removing.
+     *
+     * This event allows you to modify route (and it's articles) after it will be deleted.
+     *
+     * @Event("SWP\Bundle\ContentBundle\Event\RouteEvent")
+     *
+     * @var string
+     */
+    const POST_DELETE = 'swp.route.post_delete';
 }

--- a/src/SWP/Bundle/ContentBundle/Tests/Functional/Controller/RouteControllerTest.php
+++ b/src/SWP/Bundle/ContentBundle/Tests/Functional/Controller/RouteControllerTest.php
@@ -14,6 +14,7 @@
 
 namespace SWP\Bundle\TemplatesSystemBundle\Tests\Functional\Controller;
 
+use SWP\Bundle\ContentBundle\Model\ArticleInterface;
 use SWP\Bundle\ContentBundle\Tests\Functional\WebTestCase;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -38,16 +39,26 @@ class RouteControllerTest extends WebTestCase
     public function testCreateEmptyContentRoutesApi()
     {
         $client = static::createClient();
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'simple-test-route',
-                'type' => 'content',
-                'content' => null,
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'simple-test-route',
+                    'type' => 'content',
+                    'content' => null,
+                ],
+            ]
+        );
 
         self::assertEquals(201, $client->getResponse()->getStatusCode());
-        self::assertEquals(json_decode('{"id":1,"content":null,"staticPrefix":"\/simple-test-route","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":0,"name":"simple-test-route","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}}, "slug":"simple-test-route", "requirements":[]}', true), json_decode($client->getResponse()->getContent(), true));
+        self::assertEquals(
+            json_decode(
+                '{"id":1,"content":null,"staticPrefix":"\/simple-test-route","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":0,"name":"simple-test-route","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}}, "slug":"simple-test-route", "requirements":[]}',
+                true
+            ),
+            json_decode($client->getResponse()->getContent(), true)
+        );
     }
 
     public function testCreateContentRoutesApi()
@@ -58,40 +69,64 @@ class RouteControllerTest extends WebTestCase
         );
 
         $client = static::createClient();
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'simple-test-route',
-                'type' => 'content',
-                'content' => 2,
-                'cacheTimeInSeconds' => 1,
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'simple-test-route',
+                    'type' => 'content',
+                    'content' => 2,
+                    'cacheTimeInSeconds' => 1,
+                ],
+            ]
+        );
         $this->assertEquals(201, $client->getResponse()->getStatusCode());
 
         $content = json_decode($client->getResponse()->getContent(), true);
-        self::assertArraySubset(json_decode('{"id":2,"content":{"id":2,"title":"Test content article","body":"Test article content","slug":"test-content-article","status":"published","route":{"id":1,"content":null,"staticPrefix":null,"variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"news","position":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}}},"templateName":null,"publishStartDate":null,"publishEndDate":null,"isPublishable":true,"metadata":null,"media":[],"lead":null,"keywords":[],"_links":{"self":{"href":"\/api\/v1\/content\/articles\/test-content-article"},"online":{"href":"\/test-content-article"}}},"staticPrefix":"\/simple-test-route","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"simple-test-route","position":1,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"}}}', true), $content);
+        self::assertArraySubset(
+            json_decode(
+                '{"id":2,"content":{"id":2,"title":"Test content article","body":"Test article content","slug":"test-content-article","status":"published","route":{"id":1,"content":null,"staticPrefix":null,"variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"news","position":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}}},"templateName":null,"publishStartDate":null,"publishEndDate":null,"isPublishable":true,"metadata":null,"media":[],"lead":null,"keywords":[],"_links":{"self":{"href":"\/api\/v1\/content\/articles\/test-content-article"},"online":{"href":"\/test-content-article"}}},"staticPrefix":"\/simple-test-route","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"simple-test-route","position":1,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"}}}',
+                true
+            ),
+            $content
+        );
     }
 
     public function testCreateAndUpdateRoutesApi()
     {
         $client = static::createClient();
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'simple-test-route',
-                'type' => 'content',
-                'content' => null,
-                'cacheTimeInSeconds' => 1,
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'simple-test-route',
+                    'type' => 'content',
+                    'content' => null,
+                    'cacheTimeInSeconds' => 1,
+                ],
+            ]
+        );
 
         self::assertEquals(201, $client->getResponse()->getStatusCode());
-        self::assertArraySubset(json_decode('{"id":1,"content":null,"staticPrefix":"\/simple-test-route","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"simple-test-route","position":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}}}', true), json_decode($client->getResponse()->getContent(), true));
+        self::assertArraySubset(
+            json_decode(
+                '{"id":1,"content":null,"staticPrefix":"\/simple-test-route","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"simple-test-route","position":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}}}',
+                true
+            ),
+            json_decode($client->getResponse()->getContent(), true)
+        );
 
-        $client->request('PATCH', $this->router->generate('swp_api_content_update_routes', ['id' => 1]), [
-            'route' => [
-                'name' => 'simple-test-route-new-name',
-            ],
-        ]);
+        $client->request(
+            'PATCH',
+            $this->router->generate('swp_api_content_update_routes', ['id' => 1]),
+            [
+                'route' => [
+                    'name' => 'simple-test-route-new-name',
+                ],
+            ]
+        );
 
         self::assertEquals(200, $client->getResponse()->getStatusCode());
         self::assertArraySubset(
@@ -105,42 +140,61 @@ class RouteControllerTest extends WebTestCase
         $this->loadFixtureFiles(
             [
                 '@SWPContentBundle/Tests/Functional/app/Resources/fixtures/separate_article.yml',
-            ], 'default'
+            ],
+            'default'
         );
 
         $client = static::createClient();
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'simple-test-route',
-                'type' => 'content',
-                'content' => null,
-                'cacheTimeInSeconds' => 1,
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'simple-test-route',
+                    'type' => 'content',
+                    'content' => null,
+                    'cacheTimeInSeconds' => 1,
+                ],
+            ]
+        );
 
         $content = json_decode($client->getResponse()->getContent(), true);
         self::assertEquals(201, $client->getResponse()->getStatusCode());
 
-        $client->request('PATCH', $this->router->generate('swp_api_content_update_routes', ['id' => $content['id']]), [
-            'route' => [
-                'name' => 'simple-edited-test-route',
-                'type' => 'collection',
-                'content' => 2,
-                'cacheTimeInSeconds' => 50,
-            ],
-        ]);
+        $client->request(
+            'PATCH',
+            $this->router->generate('swp_api_content_update_routes', ['id' => $content['id']]),
+            [
+                'route' => [
+                    'name' => 'simple-edited-test-route',
+                    'type' => 'collection',
+                    'content' => 2,
+                    'cacheTimeInSeconds' => 50,
+                ],
+            ]
+        );
 
         self::assertEquals(200, $client->getResponse()->getStatusCode());
-        self::assertArraySubset(json_decode('{"content":{"title":"Test content article","body":"Test article content","slug":"test-content-article","status":"published","route":{"content":null,"staticPrefix":null,"variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"news","position":0},"templateName":null,"publishStartDate":null,"publishEndDate":null,"isPublishable":true,"metadata":null,"media":[],"lead":null},"staticPrefix":"\/simple-test-route","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":50,"name":"simple-edited-test-route","position":1}', true), json_decode($client->getResponse()->getContent(), true));
+        self::assertArraySubset(
+            json_decode(
+                '{"content":{"title":"Test content article","body":"Test article content","slug":"test-content-article","status":"published","route":{"content":null,"staticPrefix":null,"variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"news","position":0},"templateName":null,"publishStartDate":null,"publishEndDate":null,"isPublishable":true,"metadata":null,"media":[],"lead":null},"staticPrefix":"\/simple-test-route","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":50,"name":"simple-edited-test-route","position":1}',
+                true
+            ),
+            json_decode($client->getResponse()->getContent(), true)
+        );
 
         $client->request('DELETE', $this->router->generate('swp_api_content_delete_routes', ['id' => $content['id']]));
         self::assertEquals(409, $client->getResponse()->getStatusCode());
 
-        $client->request('PATCH', $this->router->generate('swp_api_content_update_routes', ['id' => $content['id']]), [
-            'route' => [
-                'content' => null,
-            ],
-        ]);
+        $client->request(
+            'PATCH',
+            $this->router->generate('swp_api_content_update_routes', ['id' => $content['id']]),
+            [
+                'route' => [
+                    'content' => null,
+                ],
+            ]
+        );
         self::assertEquals(200, $client->getResponse()->getStatusCode());
 
         $client->request('DELETE', $this->router->generate('swp_api_content_delete_routes', ['id' => $content['id']]));
@@ -150,64 +204,96 @@ class RouteControllerTest extends WebTestCase
     public function testWithCustomTemplatesRoutesApi()
     {
         $client = static::createClient();
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'simple-test-route',
-                'type' => 'content',
-                'templateName' => 'test.html.twig',
-                'cacheTimeInSeconds' => 1,
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'simple-test-route',
+                    'type' => 'content',
+                    'templateName' => 'test.html.twig',
+                    'cacheTimeInSeconds' => 1,
+                ],
+            ]
+        );
         self::assertEquals(201, $client->getResponse()->getStatusCode());
-        self::assertArraySubset(json_decode('{"content":null,"staticPrefix":"\/simple-test-route","variablePattern":null,"children":[],"level":0,"templateName":"test.html.twig","articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"simple-test-route","position":0}', true), json_decode($client->getResponse()->getContent(), true));
+        self::assertArraySubset(
+            json_decode(
+                '{"content":null,"staticPrefix":"\/simple-test-route","variablePattern":null,"children":[],"level":0,"templateName":"test.html.twig","articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"simple-test-route","position":0}',
+                true
+            ),
+            json_decode($client->getResponse()->getContent(), true)
+        );
     }
 
     public function testSettingNotSupportedRouteType()
     {
         $client = static::createClient();
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'testing-route-type',
-                'type' => 'fake-type',
-                'templateName' => 'test.html.twig',
-                'cacheTimeInSeconds' => 1,
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'testing-route-type',
+                    'type' => 'fake-type',
+                    'templateName' => 'test.html.twig',
+                    'cacheTimeInSeconds' => 1,
+                ],
+            ]
+        );
         self::assertEquals(400, $client->getResponse()->getStatusCode());
-        self::assertArraySubset(json_decode('{"code":400,"message":"Validation Failed","errors":{"children":{"name":{},"type":{"errors":["The type \"fake-type\" is not allowed. Supported types are: \"collection, content, custom\"."]}}}}', true), json_decode($client->getResponse()->getContent(), true));
+        self::assertArraySubset(
+            json_decode(
+                '{"code":400,"message":"Validation Failed","errors":{"children":{"name":{},"type":{"errors":["The type \"fake-type\" is not allowed. Supported types are: \"collection, content, custom\"."]}}}}',
+                true
+            ),
+            json_decode($client->getResponse()->getContent(), true)
+        );
     }
 
     public function testNestedRoutes()
     {
         $client = static::createClient();
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'root',
-                'type' => 'collection',
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'root',
+                    'type' => 'collection',
+                ],
+            ]
+        );
 
         $rootContent = json_decode($client->getResponse()->getContent(), true);
         self::assertEquals(201, $client->getResponse()->getStatusCode());
 
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'root-child1',
-                'type' => 'collection',
-                'parent' => $rootContent['id'],
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'root-child1',
+                    'type' => 'collection',
+                    'parent' => $rootContent['id'],
+                ],
+            ]
+        );
 
         $content = json_decode($client->getResponse()->getContent(), true);
         self::assertEquals(201, $client->getResponse()->getStatusCode());
 
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'child1-root-child1',
-                'type' => 'collection',
-                'parent' => $content['id'],
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'child1-root-child1',
+                    'type' => 'collection',
+                    'parent' => $content['id'],
+                ],
+            ]
+        );
 
         self::assertEquals(201, $client->getResponse()->getStatusCode());
 
@@ -216,46 +302,76 @@ class RouteControllerTest extends WebTestCase
         $content = json_decode($client->getResponse()->getContent(), true);
         self::assertEquals(200, $client->getResponse()->getStatusCode());
 
-        self::assertArraySubset(json_decode('{"id":1,"content":null,"staticPrefix":"\/root","variablePattern":"\/{slug}","children":[{"id":2,"content":null,"staticPrefix":"\/root\/root-child1","variablePattern":"\/{slug}","children":[{"id":3,"content":null,"staticPrefix":"\/root\/root-child1\/child1-root-child1","variablePattern":"\/{slug}","children":[],"level":2,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"child1-root-child1","position":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/3"},"parent":{"href":"\/api\/v1\/content\/routes\/2"},"root":{"href":"\/api\/v1\/content\/routes\/1"}}}],"level":1,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"root-child1","position":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"},"parent":{"href":"\/api\/v1\/content\/routes\/1"},"root":{"href":"\/api\/v1\/content\/routes\/1"}}}],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"root","position":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}}}', true), $content);
+        self::assertArraySubset(
+            json_decode(
+                '{"id":1,"content":null,"staticPrefix":"\/root","variablePattern":"\/{slug}","children":[{"id":2,"content":null,"staticPrefix":"\/root\/root-child1","variablePattern":"\/{slug}","children":[{"id":3,"content":null,"staticPrefix":"\/root\/root-child1\/child1-root-child1","variablePattern":"\/{slug}","children":[],"level":2,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"child1-root-child1","position":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/3"},"parent":{"href":"\/api\/v1\/content\/routes\/2"},"root":{"href":"\/api\/v1\/content\/routes\/1"}}}],"level":1,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"root-child1","position":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"},"parent":{"href":"\/api\/v1\/content\/routes\/1"},"root":{"href":"\/api\/v1\/content\/routes\/1"}}}],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":0,"name":"root","position":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}}}',
+                true
+            ),
+            $content
+        );
+
+        $client->request(
+            'DELETE',
+            $this->router->generate('swp_api_content_delete_routes', ['id' => $rootContent['id']])
+        );
+        self::assertEquals(409, $client->getResponse()->getStatusCode());
     }
 
     public function testAssigningNotExistingRoute()
     {
         $client = static::createClient();
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'root',
-                'type' => 'collection',
-                'parent' => 99999,
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'root',
+                    'type' => 'collection',
+                    'parent' => 99999,
+                ],
+            ]
+        );
 
         $content = json_decode($client->getResponse()->getContent(), true);
 
         self::assertEquals(400, $client->getResponse()->getStatusCode());
-        self::assertArraySubset(json_decode('{"message":"Validation Failed","errors":{"children":{"parent":{"errors":["The selected route does not exist!"]}}}}', true), $content);
+        self::assertArraySubset(
+            json_decode(
+                '{"message":"Validation Failed","errors":{"children":{"parent":{"errors":["The selected route does not exist!"]}}}}',
+                true
+            ),
+            $content
+        );
     }
 
     public function testFilterRoutesByType()
     {
         $client = static::createClient();
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'route1',
-                'type' => 'content',
-                'cacheTimeInSeconds' => 1,
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'route1',
+                    'type' => 'content',
+                    'cacheTimeInSeconds' => 1,
+                ],
+            ]
+        );
 
         self::assertEquals(201, $client->getResponse()->getStatusCode());
 
-        $client->request('POST', $this->router->generate('swp_api_content_create_routes'), [
-            'route' => [
-                'name' => 'route2',
-                'type' => 'collection',
-                'cacheTimeInSeconds' => 2,
-            ],
-        ]);
+        $client->request(
+            'POST',
+            $this->router->generate('swp_api_content_create_routes'),
+            [
+                'route' => [
+                    'name' => 'route2',
+                    'type' => 'collection',
+                    'cacheTimeInSeconds' => 2,
+                ],
+            ]
+        );
 
         self::assertEquals(201, $client->getResponse()->getStatusCode());
 
@@ -264,33 +380,104 @@ class RouteControllerTest extends WebTestCase
         self::assertEquals(200, $client->getResponse()->getStatusCode());
 
         $content = json_decode($client->getResponse()->getContent(), true);
-        self::assertEquals(json_decode('{"page":1,"limit":10,"pages":1,"total":2,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":1,"content":null,"staticPrefix":"\/route1","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"route1","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}},"slug":"route1","requirements":[]},{"id":2,"content":null,"staticPrefix":"\/route2","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":2,"name":"route2","position":1,"root":2,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"}},"slug":"route2","requirements":{"slug":"[a-zA-Z0-9*\\\-_]+"}}]}}', true), $content);
+        self::assertEquals(
+            json_decode(
+                '{"page":1,"limit":10,"pages":1,"total":2,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":1,"content":null,"staticPrefix":"\/route1","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"route1","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}},"slug":"route1","requirements":[]},{"id":2,"content":null,"staticPrefix":"\/route2","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":2,"name":"route2","position":1,"root":2,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"}},"slug":"route2","requirements":{"slug":"[a-zA-Z0-9*\\\-_]+"}}]}}',
+                true
+            ),
+            $content
+        );
 
-        $client->request('GET', $this->router->generate('swp_api_content_create_routes', [
-            'type' => 'content',
-        ]));
-
-        self::assertEquals(200, $client->getResponse()->getStatusCode());
-        $content = json_decode($client->getResponse()->getContent(), true);
-
-        self::assertEquals(json_decode('{"page":1,"limit":10,"pages":1,"total":1,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":1,"content":null,"staticPrefix":"\/route1","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"route1","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}},"slug":"route1","requirements":[]}]}}', true), $content);
-
-        $client->request('GET', $this->router->generate('swp_api_content_create_routes', [
-            'type' => 'collection',
-        ]));
-
-        self::assertEquals(200, $client->getResponse()->getStatusCode());
-        $content = json_decode($client->getResponse()->getContent(), true);
-
-        self::assertEquals(json_decode('{"page":1,"limit":10,"pages":1,"total":1,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":2,"content":null,"staticPrefix":"\/route2","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":2,"name":"route2","position":1,"root":2,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"}},"slug":"route2","requirements":{"slug":"[a-zA-Z0-9*\\\-_]+"}}]}}', true), $content);
-
-        $client->request('GET', $this->router->generate('swp_api_content_create_routes', [
-            'type' => 'fake',
-        ]));
+        $client->request(
+            'GET',
+            $this->router->generate(
+                'swp_api_content_create_routes',
+                [
+                    'type' => 'content',
+                ]
+            )
+        );
 
         self::assertEquals(200, $client->getResponse()->getStatusCode());
         $content = json_decode($client->getResponse()->getContent(), true);
 
-        self::assertEquals(json_decode('{"page":1,"limit":10,"pages":1,"total":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[]}}', true), $content);
+        self::assertEquals(
+            json_decode(
+                '{"page":1,"limit":10,"pages":1,"total":1,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":1,"content":null,"staticPrefix":"\/route1","variablePattern":null,"children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"content","cacheTimeInSeconds":1,"name":"route1","position":0,"root":1,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/1"}},"slug":"route1","requirements":[]}]}}',
+                true
+            ),
+            $content
+        );
+
+        $client->request(
+            'GET',
+            $this->router->generate(
+                'swp_api_content_create_routes',
+                [
+                    'type' => 'collection',
+                ]
+            )
+        );
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        $content = json_decode($client->getResponse()->getContent(), true);
+
+        self::assertEquals(
+            json_decode(
+                '{"page":1,"limit":10,"pages":1,"total":1,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[{"id":2,"content":null,"staticPrefix":"\/route2","variablePattern":"\/{slug}","children":[],"level":0,"templateName":null,"articlesTemplateName":null,"type":"collection","cacheTimeInSeconds":2,"name":"route2","position":1,"root":2,"parent":null,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/2"}},"slug":"route2","requirements":{"slug":"[a-zA-Z0-9*\\\-_]+"}}]}}',
+                true
+            ),
+            $content
+        );
+
+        $client->request(
+            'GET',
+            $this->router->generate(
+                'swp_api_content_create_routes',
+                [
+                    'type' => 'fake',
+                ]
+            )
+        );
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        $content = json_decode($client->getResponse()->getContent(), true);
+
+        self::assertEquals(
+            json_decode(
+                '{"page":1,"limit":10,"pages":1,"total":0,"_links":{"self":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"first":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"},"last":{"href":"\/api\/v1\/content\/routes\/?page=1&limit=10"}},"_embedded":{"_items":[]}}',
+                true
+            ),
+            $content
+        );
+    }
+
+    public function testRemoveParentRoute()
+    {
+        $this->loadFixtures(
+            [
+                'SWP\Bundle\ContentBundle\Tests\Functional\app\Resources\fixtures\LoadArticlesData',
+            ], 'default'
+        );
+
+        $client = static::createClient();
+        $client->request('DELETE', $this->router->generate('swp_api_content_delete_routes', ['id' => 2]));
+        self::assertEquals(409, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', $this->router->generate('swp_api_content_show_routes', ['id' => 4]));
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', $this->router->generate('swp_api_content_show_articles', ['id' => 8]));
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        $content = json_decode($client->getResponse()->getContent(), true);
+        self::assertEquals(ArticleInterface::STATUS_PUBLISHED, $content['status']);
+
+        $client->request('DELETE', $this->router->generate('swp_api_content_delete_routes', ['id' => 4]));
+        self::assertEquals(204, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', $this->router->generate('swp_api_content_show_articles', ['id' => 8]));
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        $content = json_decode($client->getResponse()->getContent(), true);
+        self::assertEquals(ArticleInterface::STATUS_NEW, $content['status']);
     }
 }

--- a/src/SWP/Bundle/CoreBundle/Controller/ContentListItemController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/ContentListItemController.php
@@ -158,7 +158,9 @@ class ContentListItemController extends Controller
             $data = $form->getData();
             $updatedAt = \DateTime::createFromFormat(\DateTime::RFC3339, $data['updated_at'], new \DateTimeZone('UTC'));
             $updatedAt->setTimezone(new \DateTimeZone('UTC'));
-            if ($updatedAt !== $list->getUpdatedAt()) {
+            $listUpdatedAt = $list->getUpdatedAt();
+            $listUpdatedAt->setTimezone(new \DateTimeZone('UTC'));
+            if ($updatedAt < $listUpdatedAt) {
                 throw new ConflictHttpException('List was already updated');
             }
 

--- a/src/SWP/Bundle/CoreBundle/Controller/ContentListItemController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/ContentListItemController.php
@@ -158,7 +158,7 @@ class ContentListItemController extends Controller
             $data = $form->getData();
             $updatedAt = \DateTime::createFromFormat(\DateTime::RFC3339, $data['updated_at'], new \DateTimeZone('UTC'));
             $updatedAt->setTimezone(new \DateTimeZone('UTC'));
-            if ($updatedAt != $list->getUpdatedAt()) {
+            if ($updatedAt !== $list->getUpdatedAt()) {
                 throw new ConflictHttpException('List was already updated');
             }
 

--- a/src/SWP/Bundle/CoreBundle/EventListener/RouteRemoveListener.php
+++ b/src/SWP/Bundle/CoreBundle/EventListener/RouteRemoveListener.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2018 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2018 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\EventListener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use SWP\Bundle\ContentBundle\Event\ArticleEvent;
+use SWP\Bundle\ContentBundle\Event\RouteEvent;
+use SWP\Bundle\ContentBundle\Model\Article;
+use SWP\Bundle\ContentBundle\Model\ArticleInterface;
+use SWP\Bundle\CoreBundle\Model\Package;
+use SWP\Bundle\CoreBundle\Model\PackageInterface;
+
+final class RouteRemoveListener
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $manager;
+
+    /**
+     * RouteRemoveListener constructor.
+     *
+     * @param EntityManagerInterface $manager
+     */
+    public function __construct(EntityManagerInterface $manager)
+    {
+        $this->manager = $manager;
+    }
+
+    /**
+     * @param ArticleEvent $event
+     */
+    public function onDelete(RouteEvent $event)
+    {
+        $route = $event->getRoute();
+        $queryBuilder = $this->manager->createQueryBuilder();
+        $queryBuilder->update(Package::class, 'p')
+            ->set('p.status', $queryBuilder->expr()->literal(PackageInterface::STATUS_USABLE))
+            ->where('p.id IN (SELECT a.id FROM SWP\Bundle\CoreBundle\Model\Article a WHERE a.route = :route AND a.package = p.id)')
+            ->setParameter('route', $route->getId())
+            ->getQuery()
+            ->execute();
+
+        $queryBuilder = $this->manager->createQueryBuilder();
+        $queryBuilder->update(Article::class, 'a')
+            ->set('a.status', $queryBuilder->expr()->literal(ArticleInterface::STATUS_NEW))
+            ->where('a.route = :route')
+            ->setParameter('route', $route->getId())
+            ->getQuery()
+            ->execute();
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -295,6 +295,12 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
+    SWP\Bundle\CoreBundle\EventListener\RouteRemoveListener:
+        arguments:
+            - '@doctrine.orm.entity_manager'
+        tags:
+            - { name: kernel.event_listener, event: swp.route.pre_delete, method: onDelete }
+
     swp.matcher.article_criteria:
         class: SWP\Bundle\CoreBundle\Matcher\ArticleCriteriaMatcher
 

--- a/src/SWP/Bundle/CoreBundle/Tests/Controller/ContentListItemControllerTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Controller/ContentListItemControllerTest.php
@@ -285,7 +285,6 @@ class ContentListItemControllerTest extends WebTestCase
         ]);
         self::assertEquals(201, $this->client->getResponse()->getStatusCode());
         $listData = json_decode($this->client->getResponse()->getContent(), true);
-        $listUpdatedAt = $listData['updatedAt'];
         $this->client->request('GET', $listData['_links']['items']['href']);
         $listItems = json_decode($this->client->getResponse()->getContent(), true);
         self::assertCount(4, $listItems['_embedded']['_items']);

--- a/src/SWP/Bundle/CoreBundle/Tests/Controller/RouteControllerTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Controller/RouteControllerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2016 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2016 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Tests\Controller;
+
+use SWP\Bundle\ContentBundle\Model\ArticleInterface;
+use SWP\Bundle\CoreBundle\Model\PackageInterface;
+use SWP\Bundle\FixturesBundle\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class RouteControllerTest extends WebTestCase
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        self::bootKernel();
+        $this->initDatabase();
+        $this->loadCustomFixtures(['tenant', 'article']);
+        $this->router = $this->getContainer()->get('router');
+    }
+
+    public function testRemoveParentRoute()
+    {
+        $client = static::createClient();
+        $client->request('DELETE', $this->router->generate('swp_api_content_delete_routes', ['id' => 3]));
+        self::assertEquals(409, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', $this->router->generate('swp_api_content_show_routes', ['id' => 6]));
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', $this->router->generate('swp_api_content_show_articles', ['id' => 2]));
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        $content = json_decode($client->getResponse()->getContent(), true);
+        self::assertEquals(ArticleInterface::STATUS_PUBLISHED, $content['status']);
+
+        $client->request('GET', $this->router->generate('swp_api_core_show_package', ['id' => 2]));
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        $content = json_decode($client->getResponse()->getContent(), true);
+        self::assertEquals(PackageInterface::STATUS_PUBLISHED, $content['status']);
+
+        $client->request('DELETE', $this->router->generate('swp_api_content_delete_routes', ['id' => 6]));
+        self::assertEquals(204, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', $this->router->generate('swp_api_content_show_articles', ['id' => 2]));
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        $content = json_decode($client->getResponse()->getContent(), true);
+        self::assertEquals(ArticleInterface::STATUS_NEW, $content['status']);
+
+        $client->request('GET', $this->router->generate('swp_api_core_show_package', ['id' => 2]));
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        $content = json_decode($client->getResponse()->getContent(), true);
+        self::assertEquals(PackageInterface::STATUS_USABLE, $content['status']);
+    }
+}


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | no
| New feature?              | yes
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | no
| Fixed tickets             | SWP-1145
| License                   | AGPLv3


From now before removing route user will need to remove all child routes first.