### PR TITLE
Fixed handling of a single superdesk server in parameters.yml

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Controller/AuthController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/AuthController.php
@@ -97,7 +97,7 @@ class AuthController extends Controller
         $form->handleRequest($request);
         if ($form->isValid()) {
             $formData = $form->getData();
-            $authorizedSuperdeskHosts = $this->container->getParameter('superdesk_servers');
+            $authorizedSuperdeskHosts = (array) $this->container->getParameter('superdesk_servers');
             $superdeskUser = null;
             $client = new GuzzleHttp\Client();
 

--- a/src/SWP/Bundle/CoreBundle/Tests/Controller/AuthControllerTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Controller/AuthControllerTest.php
@@ -202,7 +202,7 @@ class AuthControllerTest extends WebTestCase
     public function testSuperdeskAuthentication()
     {
         try {
-            $baseUrl = $this->getContainer()->getParameter('superdesk_servers')[0];
+            $baseUrl = ((array) $this->getContainer()->getParameter('superdesk_servers'))[0];
             $client = new GuzzleHttp\Client();
             $apiRequest = new GuzzleHttp\Psr7\Request('GET', $baseUrl.'/api/sessions');
             $client->send($apiRequest);


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes|
| New feature?              |no
| BC breaks?                |no
| Deprecations?             |no
| Tests pass?               | yes
| Changelog update required |no
| Fixed tickets             | #562 
| License                   | AGPLv3

Hi. First time adding to Publisher so I hope it's ok. It adds compatibility to allow a single superdesk server to be written into the parameters.yml file, as I experienced a bug related to it [here](https://github.com/superdesk/web-publisher/issues/562).