### PR TITLE
[improvement] add exclude_article handling to article loader

### DIFF
--- a/docs/manual/templates_system/articles.rst
+++ b/docs/manual/templates_system/articles.rst
@@ -60,3 +60,18 @@ The :code:`articles` loader parameters:
     {% gimmelist article from articles with {'keywords':['keyword1', 'keyword2']} %}
         <img src="{{ url(article) }}" />
     {% endgimmelist %}
+
+
+* Filtering out selected articles (useful when you want to exclude articles listed already in content list)
+
+.. code-block:: twig
+
+    {% gimmelist article from articles without {article:[1,2]} %} <!-- pass articles ids (collected before) -->
+        <img src="{{ url(article) }}" />
+    {% endgimmelist %}
+
+.. code-block:: twig
+
+    {% gimmelist article from articles without {article:[gimme.article]} %} <!-- pass articles meta objects -->
+        <img src="{{ url(article) }}" />
+    {% endgimmelist %}

--- a/docs/manual/templates_system/content_list.rst
+++ b/docs/manual/templates_system/content_list.rst
@@ -54,6 +54,7 @@ or
 
 
 .. code-block:: twig
+
     {% gimme contentList with { contentListName: "List1"} %}
         {% cache 'top-articles' {gen: contentList} %}
         <ul>

--- a/src/SWP/Bundle/ContentBundle/Loader/ArticleLoader.php
+++ b/src/SWP/Bundle/ContentBundle/Loader/ArticleLoader.php
@@ -136,7 +136,7 @@ class ArticleLoader extends PaginatedLoader implements LoaderInterface
                 $criteria->set('route', $route);
             }
 
-            foreach (['metadata', 'keywords', 'source', 'author'] as $item) {
+            foreach (['metadata', 'keywords', 'source', 'author', 'article'] as $item) {
                 if (isset($parameters[$item])) {
                     $criteria->set($item, $parameters[$item]);
                 }

--- a/src/SWP/Bundle/CoreBundle/Tests/Loader/ArticleLoaderTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Loader/ArticleLoaderTest.php
@@ -135,7 +135,7 @@ class ArticleLoaderTest extends WebTestCase
         self::assertNotContains('John Doe', $result);
     }
 
-    public function testFilteringByInvludedAndExcludedAuthors()
+    public function testFilteringByIncludedAndExcludedAuthors()
     {
         $template = '{% gimmelist article from articles with {author: ["Tom"]} without {author: ["Test Person", "John Doe"]} %} {% for author in article.authors %} {{ author.name }} {% endfor %} {% endgimmelist %}';
         $result = $this->getRendered($template);
@@ -143,6 +143,14 @@ class ArticleLoaderTest extends WebTestCase
         self::assertContains('Tom', $result);
         self::assertNotContains('Test Person', $result);
         self::assertNotContains('John Doe', $result);
+    }
+
+    public function testFilteringByExcludedArticles()
+    {
+        $template = '{% gimme article with {id: 1} %}{% gimmelist article from articles without {article: [article, 2]} %} {{ article.slug }} (id: {{ article.id }}) {% endgimmelist %}{% endgimme %}';
+        $result = $this->getRendered($template);
+
+        self::assertEquals(' test-article (id: 3)  features (id: 4)  features-client1 (id: 5) ', $result);
     }
 
     private function getRendered($template, $context = [])


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | no
| New feature?              | yes
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | no
| Fixed tickets             | SWP-1302
| License                   | AGPLv3

Filtering out selected articles (useful when you want to exclude articles listed already in content list)

```
{% gimmelist article from articles without {article:[1,2]} %} <!-- pass articles ids (collected before) -->
    <img src="{{ url(article) }}" /> {
% endgimmelist %}
```

```
{% gimmelist article from articles without {article:[gimme.article]} %} <!-- pass articles meta objects -->
    <img src="{{ url(article) }}" />
{% endgimmelist %}
```



