### PR TITLE
[feature] add collection loading to route loader

### DIFF
--- a/docs/manual/templates_system/routes.rst
+++ b/docs/manual/templates_system/routes.rst
@@ -19,3 +19,25 @@ Usage:
 - ``parent`` - an id of parent route
 - ``slug`` - route's slug
 - ``name`` - route's name
+
+
+Listing a Routes Collection
+---------------------------
+
+Usage:
+
+.. code-block:: twig
+
+    <ul>
+    {% gimmelist route %}
+        <li>{{ route.name }}
+    {% endgimme %}
+    </ul>
+
+.. code-block:: twig
+
+    <ul>
+    {% gimmelist route with {parent: 5} %} <!-- possible values for parrent: (int) 5, (string) 'Test Route', (meta) gimme.route -->
+        <li>{{ route.name }}
+    {% endgimme %}
+    </ul>

--- a/docs/manual/templates_system/routes.rst
+++ b/docs/manual/templates_system/routes.rst
@@ -37,7 +37,7 @@ Usage:
 .. code-block:: twig
 
     <ul>
-    {% gimmelist route with {parent: 5} %} <!-- possible values for parrent: (int) 5, (string) 'Test Route', (meta) gimme.route -->
+    {% gimmelist route with {parent: 5} %} <!-- possible values for parent: (int) 5, (string) 'Test Route', (meta) gimme.route -->
         <li>{{ route.name }}
     {% endgimme %}
     </ul>

--- a/src/SWP/Bundle/ContentBundle/Doctrine/ORM/RouteRepository.php
+++ b/src/SWP/Bundle/ContentBundle/Doctrine/ORM/RouteRepository.php
@@ -17,6 +17,7 @@ namespace SWP\Bundle\ContentBundle\Doctrine\ORM;
 use Doctrine\ORM\QueryBuilder;
 use SWP\Bundle\ContentBundle\Model\RouteRepositoryInterface;
 use SWP\Bundle\StorageBundle\Doctrine\ORM\EntityRepository;
+use SWP\Component\Common\Criteria\Criteria;
 
 class RouteRepository extends EntityRepository implements RouteRepositoryInterface
 {
@@ -30,5 +31,15 @@ class RouteRepository extends EntityRepository implements RouteRepositoryInterfa
         $this->applySorting($queryBuilder, $orderBy, 'r');
 
         return $queryBuilder;
+    }
+
+    public function countByCriteria(Criteria $criteria): int
+    {
+        $queryBuilder = $this->createQueryBuilder('r')
+            ->select('COUNT(r.id)');
+
+        $this->applyCriteria($queryBuilder, $criteria, 'r');
+
+        return (int) $queryBuilder->getQuery()->getSingleScalarResult();
     }
 }

--- a/src/SWP/Bundle/ContentBundle/Loader/RouteLoader.php
+++ b/src/SWP/Bundle/ContentBundle/Loader/RouteLoader.php
@@ -16,15 +16,18 @@ declare(strict_types=1);
 
 namespace SWP\Bundle\ContentBundle\Loader;
 
+use SWP\Bundle\ContentBundle\Model\RouteInterface;
 use SWP\Bundle\ContentBundle\Model\RouteRepositoryInterface;
 use SWP\Component\Common\Criteria\Criteria;
 use SWP\Component\TemplatesSystem\Gimme\Factory\MetaFactoryInterface;
 use SWP\Component\TemplatesSystem\Gimme\Loader\LoaderInterface;
+use SWP\Component\TemplatesSystem\Gimme\Meta\Meta;
+use SWP\Component\TemplatesSystem\Gimme\Meta\MetaCollection;
 
 /**
  * Class RouteLoader.
  */
-class RouteLoader implements LoaderInterface
+class RouteLoader extends PaginatedLoader implements LoaderInterface
 {
     const SUPPORTED_TYPE = 'route';
 
@@ -60,28 +63,64 @@ class RouteLoader implements LoaderInterface
      */
     public function load($type, $parameters = [], $withoutParameters = [], $responseType = LoaderInterface::SINGLE)
     {
-        $route = isset($parameters['route_object']) ? $parameters['route_object'] : null;
+        if (LoaderInterface::SINGLE === $responseType) {
+            $route = isset($parameters['route_object']) ? $parameters['route_object'] : null;
+            if (null === $route) {
+                if (empty($parameters)) {
+                    return false;
+                }
 
-        if (null === $route) {
-            if (empty($parameters)) {
-                return false;
+                $criteria = new Criteria();
+                foreach ($this->supportedParameters as $supportedParameter) {
+                    if (array_key_exists($supportedParameter, $parameters)) {
+                        $criteria->set($supportedParameter, $parameters[$supportedParameter]);
+                    }
+                }
+
+                $route = $this->routeRepository->getQueryByCriteria($criteria, [], 'r')
+                    ->setMaxResults(1)
+                    ->getQuery()
+                    ->getOneOrNullResult();
             }
 
+            if (null !== $route) {
+                return $this->metaFactory->create($route);
+            }
+        } elseif (LoaderInterface::COLLECTION === $responseType) {
             $criteria = new Criteria();
-            foreach ($this->supportedParameters as $supportedParameter) {
-                if (array_key_exists($supportedParameter, $parameters)) {
-                    $criteria->set($supportedParameter, $parameters[$supportedParameter]);
+
+            if (\array_key_exists('parent', $parameters)) {
+                $parent = $parameters['parent'];
+                if (is_numeric($parent)) {
+                    $criteria->set('parent', $parent);
+                } elseif (\is_string($parent)) {
+                    $parentObject = $this->routeRepository->getQueryByCriteria(new Criteria(['name' => $parent]), $criteria->get('order', []), 'r')
+                        ->getQuery()->getOneOrNullResult();
+                    if (null !== $parentObject) {
+                        $criteria->set('parent', $parentObject->getId());
+                    }
+                } elseif ($parent instanceof Meta && $parent->getValues() instanceof RouteInterface) {
+                    $criteria->set('parent', $parent->getValues()->getId());
                 }
             }
 
-            $route = $this->routeRepository->getQueryByCriteria($criteria, [], 'r')
-                ->setMaxResults(1)
-                ->getQuery()
-                ->getOneOrNullResult();
-        }
+            $this->applyPaginationToCriteria($criteria, $parameters);
+            $countCriteria = clone $criteria;
+            $routesCollection = $this->routeRepository->getQueryByCriteria($criteria, $criteria->get('order', []), 'r')->getQuery()->getResult();
 
-        if (null !== $route) {
-            return $this->metaFactory->create($route);
+            if (\count($routesCollection) > 0) {
+                $metaCollection = new MetaCollection();
+                $metaCollection->setTotalItemsCount($this->routeRepository->countByCriteria($countCriteria));
+                foreach ($routesCollection as $route) {
+                    $routeMeta = $this->metaFactory->create($route);
+                    if (null !== $routeMeta) {
+                        $metaCollection->add($routeMeta);
+                    }
+                }
+                unset($routesCollection, $route, $criteria);
+
+                return $metaCollection;
+            }
         }
 
         return false;

--- a/src/SWP/Bundle/ContentBundle/Model/RouteRepositoryInterface.php
+++ b/src/SWP/Bundle/ContentBundle/Model/RouteRepositoryInterface.php
@@ -3,6 +3,7 @@
 namespace SWP\Bundle\ContentBundle\Model;
 
 use Doctrine\ORM\QueryBuilder;
+use SWP\Component\Common\Criteria\Criteria;
 use SWP\Component\Storage\Repository\RepositoryInterface;
 
 interface RouteRepositoryInterface extends RepositoryInterface
@@ -14,4 +15,6 @@ interface RouteRepositoryInterface extends RepositoryInterface
      * @return QueryBuilder
      */
     public function getChildrenByStaticPrefix(array $candidates, array $orderBy): QueryBuilder;
+
+    public function countByCriteria(Criteria $criteria): int;
 }

--- a/src/SWP/Bundle/ContentBundle/Tests/Functional/RouteLoaderTest.php
+++ b/src/SWP/Bundle/ContentBundle/Tests/Functional/RouteLoaderTest.php
@@ -15,6 +15,7 @@
 namespace SWP\Bundle\ContentBundle\Tests;
 
 use SWP\Bundle\ContentBundle\Loader\RouteLoader;
+use SWP\Bundle\ContentBundle\Tests\Functional\app\Resources\fixtures\LoadArticlesData;
 use SWP\Bundle\ContentBundle\Tests\Functional\WebTestCase;
 use SWP\Component\TemplatesSystem\Gimme\Loader\LoaderInterface;
 use SWP\Component\TemplatesSystem\Gimme\Meta\MetaCollection;
@@ -28,11 +29,7 @@ class RouteLoaderTest extends WebTestCase
     {
         self::bootKernel();
 
-        $this->loadFixtures(
-            [
-                'SWP\Bundle\ContentBundle\Tests\Functional\app\Resources\fixtures\LoadArticlesData',
-            ], 'default'
-        );
+        $this->loadFixtures([LoadArticlesData::class]);
     }
 
     public function testFindRoute()

--- a/src/SWP/Bundle/ContentBundle/Tests/Functional/RouteLoaderTest.php
+++ b/src/SWP/Bundle/ContentBundle/Tests/Functional/RouteLoaderTest.php
@@ -16,6 +16,8 @@ namespace SWP\Bundle\ContentBundle\Tests;
 
 use SWP\Bundle\ContentBundle\Loader\RouteLoader;
 use SWP\Bundle\ContentBundle\Tests\Functional\WebTestCase;
+use SWP\Component\TemplatesSystem\Gimme\Loader\LoaderInterface;
+use SWP\Component\TemplatesSystem\Gimme\Meta\MetaCollection;
 
 class RouteLoaderTest extends WebTestCase
 {
@@ -25,6 +27,12 @@ class RouteLoaderTest extends WebTestCase
     public function setUp()
     {
         self::bootKernel();
+
+        $this->loadFixtures(
+            [
+                'SWP\Bundle\ContentBundle\Tests\Functional\app\Resources\fixtures\LoadArticlesData',
+            ], 'default'
+        );
     }
 
     public function testFindRoute()
@@ -39,5 +47,33 @@ class RouteLoaderTest extends WebTestCase
 
         $meta = $routeLoader->load('route', []);
         $this->assertFalse($meta);
+    }
+
+    public function testFindRoutesCollection()
+    {
+        $routeLoader = new RouteLoader(
+            $this->getContainer()->get('swp_template_engine_context.factory.meta_factory'),
+            $this->getContainer()->get('swp.repository.route')
+        );
+
+        $collection = $routeLoader->load('route', [], [], LoaderInterface::COLLECTION);
+        self::assertInstanceOf(MetaCollection::class, $collection);
+        self::assertEquals(4, $collection->count());
+
+        $collection = $routeLoader->load('route', ['parent' => 2], [], LoaderInterface::COLLECTION);
+        self::assertInstanceOf(MetaCollection::class, $collection);
+        self::assertEquals(1, $collection->count());
+
+        $collection = $routeLoader->load('route', ['parent' => 3], [], LoaderInterface::COLLECTION);
+        self::assertFalse($collection);
+
+        $collection = $routeLoader->load('route', ['parent' => 'articles'], [], LoaderInterface::COLLECTION);
+        self::assertInstanceOf(MetaCollection::class, $collection);
+        self::assertEquals(1, $collection->count());
+
+        $meta = $routeLoader->load('route', ['name' => 'articles']);
+        $collection = $routeLoader->load('route', ['parent' => $meta], [], LoaderInterface::COLLECTION);
+        self::assertInstanceOf(MetaCollection::class, $collection);
+        self::assertEquals(1, $collection->count());
     }
 }


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | no
| New feature?              | yes
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | no
| Fixed tickets             | SWP-1306
| License                   | AGPLv3

Listing a Routes Collection
---------------------------

Usage:

```
    <ul>
    {% gimmelist route %}
        <li>{{ route.name }}
    {% endgimme %}
    </ul>
```
```
    <ul>
    {% gimmelist route with {parent: 5} %} <!-- possible values for parrent: (int) 5, (string) 'Test Route', (meta) gimme.route -->
        <li>{{ route.name }}
    {% endgimme %}
    </ul>
```