### PR TITLE
always install all defined in theme data (without articles). Generat…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
     },
     "require": {
         "php": "^7.1",
+        "ext-json": "*",
+        "ext-curl": "*",
+        "ext-zip": "*",
         "symfony/symfony": "3.4.14",
         "symfony/swiftmailer-bundle": "~3.0",
         "symfony/monolog-bundle": "~3.0",

--- a/src/SWP/Bundle/CoreBundle/Theme/Generator/GeneratorInterface.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Generator/GeneratorInterface.php
@@ -18,8 +18,5 @@ namespace SWP\Bundle\CoreBundle\Theme\Generator;
 
 interface GeneratorInterface
 {
-    /**
-     * @param array $data
-     */
-    public function generate(array $data): void;
+    public function generate(array $data, bool $applyOptionalData): void;
 }

--- a/src/SWP/Bundle/CoreBundle/Theme/Generator/ThemeContainersGenerator.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Generator/ThemeContainersGenerator.php
@@ -63,7 +63,7 @@ class ThemeContainersGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate(array $containers): void
+    public function generate(array $containers, bool $applyOptionalData): void
     {
         foreach ($containers as $containerData) {
             if (null !== $this->containerRepository->findOneByName($containerData['name'])) {

--- a/src/SWP/Bundle/CoreBundle/Theme/Generator/ThemeContentListsGenerator.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Generator/ThemeContentListsGenerator.php
@@ -72,7 +72,7 @@ class ThemeContentListsGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate(array $contentLists): void
+    public function generate(array $contentLists, bool $applyOptionalData): void
     {
         foreach ($contentLists as $contentListData) {
             if (null !== $this->contentListRepository->findOneByName($contentListData['name'])) {

--- a/src/SWP/Bundle/CoreBundle/Theme/Generator/ThemeMenusGenerator.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Generator/ThemeMenusGenerator.php
@@ -72,7 +72,7 @@ class ThemeMenusGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate(array $menus, MenuItemInterface $parent = null): void
+    public function generate(array $menus, bool $applyOptionalData, MenuItemInterface $parent = null): void
     {
         foreach ($menus as $menuData) {
             if (null !== $this->menuRepository->findOneBy(['name' => $menuData['name'], 'parent' => $parent])) {
@@ -105,7 +105,7 @@ class ThemeMenusGenerator implements GeneratorInterface
         $this->menuRepository->add($menu);
 
         if (null !== $children) {
-            $this->generate($children, $menu);
+            $this->generate($children, false, $menu);
         }
     }
 

--- a/src/SWP/Bundle/CoreBundle/Theme/Generator/ThemeRoutesGenerator.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Generator/ThemeRoutesGenerator.php
@@ -80,7 +80,7 @@ class ThemeRoutesGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate(array $routes): void
+    public function generate(array $routes, bool $applyOptionalData): void
     {
         foreach ($routes as $routeData) {
             $cleanRouteData = $routeData;
@@ -91,7 +91,9 @@ class ThemeRoutesGenerator implements GeneratorInterface
                 continue;
             }
 
-            $this->processFakeArticles($route, $routeData);
+            if ($applyOptionalData) {
+                $this->processFakeArticles($route, $routeData);
+            }
 
             $this->routeRepository->add($route);
         }

--- a/src/SWP/Bundle/CoreBundle/Theme/Generator/ThemeWidgetsGenerator.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Generator/ThemeWidgetsGenerator.php
@@ -72,7 +72,7 @@ class ThemeWidgetsGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate(array $widgets): void
+    public function generate(array $widgets, bool $applyOptionalData): void
     {
         foreach ($widgets as $widgetData) {
             if (null !== $this->widgetModelRepository->findOneByName($widgetData['name'])) {

--- a/src/SWP/Bundle/CoreBundle/Theme/Processor/RequiredDataProcessor.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Processor/RequiredDataProcessor.php
@@ -68,12 +68,12 @@ class RequiredDataProcessor implements RequiredDataProcessorInterface
     /**
      * {@inheritdoc}
      */
-    public function processTheme(ThemeInterface $theme): void
+    public function processTheme(ThemeInterface $theme, bool $applyOptionalData = false): void
     {
-        $this->themeRoutesGenerator->generate($theme->getRoutes());
-        $this->themeMenusGenerator->generate($theme->getMenus());
-        $this->themeContainersGenerator->generate($theme->getContainers());
-        $this->themeContentListsGenerator->generate($theme->getContentLists());
-        $this->themeWidgetsGenerator->generate($theme->getWidgets());
+        $this->themeRoutesGenerator->generate($theme->getRoutes(), $applyOptionalData);
+        $this->themeMenusGenerator->generate($theme->getMenus(), $applyOptionalData);
+        $this->themeContainersGenerator->generate($theme->getContainers(), $applyOptionalData);
+        $this->themeContentListsGenerator->generate($theme->getContentLists(), $applyOptionalData);
+        $this->themeWidgetsGenerator->generate($theme->getWidgets(), $applyOptionalData);
     }
 }

--- a/src/SWP/Bundle/CoreBundle/Theme/Processor/RequiredDataProcessorInterface.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Processor/RequiredDataProcessorInterface.php
@@ -16,13 +16,7 @@ namespace SWP\Bundle\CoreBundle\Theme\Processor;
 
 use SWP\Bundle\CoreBundle\Theme\Model\ThemeInterface;
 
-/**
- * Interface ThemeUploaderInterface.
- */
 interface RequiredDataProcessorInterface
 {
-    /**
-     * @param ThemeInterface $theme
-     */
-    public function processTheme(ThemeInterface $theme): void;
+    public function processTheme(ThemeInterface $theme, bool $applyOptionalData = false): void;
 }

--- a/src/SWP/Bundle/CoreBundle/Theme/Service/ThemeService.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Service/ThemeService.php
@@ -131,6 +131,7 @@ final class ThemeService implements ThemeServiceInterface
             /** @var ThemeInterface $theme */
             $theme = $this->themeRepository->findOneByName($this->themeContext->resolveThemeName($tenant, $themeName));
             $this->requiredDataProcessor->processTheme($theme, $processOptionalData);
+            $this->tenantRepository->flush();
             $messages[] = 'Required data were generated and persisted successfully';
             if ($processOptionalData) {
                 $messages[] = 'Optional data were generated and persisted successfully';

--- a/src/SWP/Bundle/CoreBundle/Theme/Service/ThemeServiceInterface.php
+++ b/src/SWP/Bundle/CoreBundle/Theme/Service/ThemeServiceInterface.php
@@ -17,21 +17,11 @@ namespace SWP\Bundle\CoreBundle\Theme\Service;
 interface ThemeServiceInterface
 {
     /**
-     * @param string $sourceDir
-     * @param string $themeDir
-     * @param bool   $processGeneratedData
-     * @param bool   $activate
-     *
-     * @return mixed
-     */
-    public function installAndProcessGeneratedData(string $sourceDir, string $themeDir, $processGeneratedData = false, $activate = false);
-
-    /**
-     * @param string $themeName
-     *
      * @throws \Exception
      *
      * @return array
      */
+    public function installAndProcessGeneratedData(string $sourceDir, string $themeDir, bool $processOptionalData = false, bool $activate = false);
+
     public function getDirectoriesForTheme(string $themeName): array;
 }


### PR DESCRIPTION
…e articles only when enabled on theme installation call

| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | yes - theme defined generated data will be allways installed (without articles) by default
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | no
| Fixed tickets             | SWP-1210
| License                   | AGPLv3
