### PR TITLE
save mp3 files with mp3 extension instead of mpga

### DIFF
--- a/features/content_push/send_content_with_embedded_audio.feature
+++ b/features/content_push/send_content_with_embedded_audio.feature
@@ -13,7 +13,7 @@ Feature: Handling embedded audio
     Then the response status code should be 201
     And the JSON node "media_id" should be equal to "20180904130932/0a6343fb0e968150fc538404b5b72ed9279b9b42edf4c501057a44499c8148d6.mp3"
     And the JSON node "mime_type" should be equal to "audio/mpeg"
-    And the JSON node "URL" should be equal to "http://localhost/media/20180904130932_0a6343fb0e968150fc538404b5b72ed9279b9b42edf4c501057a44499c8148d6.mpga"
+    And the JSON node "URL" should be equal to "http://localhost/media/20180904130932_0a6343fb0e968150fc538404b5b72ed9279b9b42edf4c501057a44499c8148d6.mp3"
     And the JSON node "media" should not be null
 
     When I add "Content-Type" header equal to "application/json"
@@ -118,9 +118,9 @@ Feature: Handling embedded audio
     And I add "Content-Type" header equal to "application/json"
     Then I send a "GET" request to "/api/v1/content/articles/test-audio-in-body"
     Then the response status code should be 200
-    And the JSON node "body" should contain "/media/20180904130932_0a6343fb0e968150fc538404b5b72ed9279b9b42edf4c501057a44499c8148d6.mpga"
+    And the JSON node "body" should contain "/media/20180904130932_0a6343fb0e968150fc538404b5b72ed9279b9b42edf4c501057a44499c8148d6.mp3"
     And the JSON nodes should contain:
-      | media[0].file.assetId         | 20180904130932_0a6343fb0e968150fc538404b5b72ed9279b9b42edf4c501057a44499c8148d6             |
-      | media[0].file.fileExtension   | mpga                                                                                        |
-      | media[0]._links.download.href | /media/20180904130932_0a6343fb0e968150fc538404b5b72ed9279b9b42edf4c501057a44499c8148d6.mpga |
+      | media[0].file.assetId         | 20180904130932_0a6343fb0e968150fc538404b5b72ed9279b9b42edf4c501057a44499c8148d6            |
+      | media[0].file.fileExtension   | mp3                                                                                        |
+      | media[0]._links.download.href | /media/20180904130932_0a6343fb0e968150fc538404b5b72ed9279b9b42edf4c501057a44499c8148d6.mp3 |
     And the JSON node "media[0].image" should be null

--- a/src/SWP/Bundle/ContentBundle/Manager/MediaManager.php
+++ b/src/SWP/Bundle/ContentBundle/Manager/MediaManager.php
@@ -99,7 +99,8 @@ class MediaManager implements MediaManagerInterface
      */
     public function saveFile(UploadedFile $uploadedFile, $fileName)
     {
-        $filePath = $this->getMediaBasePath().'/'.$fileName.'.'.$uploadedFile->guessExtension();
+        $extension = $this->guessExtension($uploadedFile);
+        $filePath = $this->getMediaBasePath().'/'.$fileName.'.'.$extension;
 
         if ($this->filesystem->has($filePath)) {
             return true;
@@ -136,7 +137,9 @@ class MediaManager implements MediaManagerInterface
      */
     public function createMediaAsset(UploadedFile $uploadedFile, string $assetId): FileInterface
     {
-        return $this->fileFactory->createWith($assetId, $uploadedFile->guessExtension());
+        $extension = $this->guessExtension($uploadedFile);
+
+        return $this->fileFactory->createWith($assetId, $extension);
     }
 
     /**
@@ -147,5 +150,16 @@ class MediaManager implements MediaManagerInterface
         $pathElements = ['swp', 'media'];
 
         return implode('/', $pathElements);
+    }
+
+    private function guessExtension(UploadedFile $uploadedFile): string
+    {
+        $extension = $uploadedFile->guessExtension();
+
+        if ('mpga' === $extension && 'mp3' === $uploadedFile->getExtension()) {
+            $extension = 'mp3';
+        }
+
+        return $extension;
     }
 }


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | no
| License                   | AGPLv3

Store `mp3` files with `mp3` extension, not with `mpga`