### PR TITLE
[WIP] persist new package before merge in case of new relations created

### DIFF
--- a/src/SWP/Bundle/ContentBundle/Controller/ContentPushController.php
+++ b/src/SWP/Bundle/ContentBundle/Controller/ContentPushController.php
@@ -65,6 +65,8 @@ class ContentPushController extends Controller
                 'package' => $existingPackage,
             ]));
 
+            // Persist it first so added with correction elements will be handled properly
+            $objectManager->persist($package);
             $package = $objectManager->merge($package);
             $objectManager->flush();
 


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | yes
| New feature?              | no
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | no
| Fixed tickets             | 
| License                   | AGPLv3

We could reproduce it only on production and prelive instances - in tests all is ok every time. Problem is visible when new serialized package have groups added and they are not existing in old package - so merge is not enough to save that group entity -  it require persist to tell for manager that it should be saved.
