### PR TITLE
Allow to change the article's slug based on settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ To get the diff for a specific change, go to https://github.com/superdesk/web-pu
  * improvement [#630] Add option to exclude articles fron content list items
 
 ### 1.4.1
+ * feature [#715] Allow to change the article's slug based on settings
  * bug [#708] Allow to render AMP HTML version of content with route of type "content"
  * feature [#706] Added Console Command which processes articles' body
  * feature [#699] Allow to blacklist specific article keywords

--- a/features/content_push/correcting_published_package.feature
+++ b/features/content_push/correcting_published_package.feature
@@ -145,3 +145,4 @@ Feature: Checking if package corrections work fine
     And the JSON nodes should contain:
       | headline                | testing correction corrected    |
       | status                  | published                       |
+      | slugline                | abstract-html-test-corrected    |

--- a/features/content_push/correcting_slugline_of_published_package.feature
+++ b/features/content_push/correcting_slugline_of_published_package.feature
@@ -1,0 +1,213 @@
+@content_push
+Feature: Allow to change the article's slug based on settings.
+  In order to change article's slugline on package correction
+  As a HTTP Client
+  I want to be able to override it by changing the settings
+
+  Scenario: Override slugline
+    Given I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/api/v1/content/push" with body:
+    """
+    {
+      "readtime":57,
+      "ednote":"In the story \"datenschutz\"  sent at: 29/01/2019 15:35\r\n\r\nThis is corrected repeat.",
+      "copyrightnotice":"",
+      "type":"text",
+      "charcount":113634,
+      "versioncreated":"2019-01-29T15:11:06+0000",
+      "language":"en",
+      "firstpublished":"2019-01-14T09:51:49+0000",
+      "body_html":"<h1>Richtlinien zum Datenschutz</h1>",
+      "copyrightholder":"",
+      "urgency":3,
+      "headline":"Richtlinien zum Datenschutz",
+      "extra":{
+        "seotitle":"Richtlinien zum Datenschutz"
+      },
+      "usageterms":"",
+      "wordcount":14364,
+      "version":"7",
+      "profile":"NachrichtenFG",
+      "pubstatus":"usable",
+      "priority":6,
+      "service":[
+        {
+          "code":"serv",
+          "name":"Service"
+        }
+      ],
+      "firstcreated":"2019-01-14T09:09:56+0000",
+      "annotations":[
+
+      ],
+      "source":"fg",
+      "guid":"dc8fcbb4-22f2-4e0b-bd24-7714ce8d865a"
+    }
+    """
+    Then the response status code should be 201
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/{version}/packages/6"
+    Then the response status code should be 200
+    And the JSON nodes should contain:
+      | headline                | Richtlinien zum Datenschutz     |
+      | status                  | new                             |
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "POST" request to "/api/v1/packages/6/publish/" with body:
+     """
+      {
+        "publish":{
+          "destinations":[
+            {
+              "tenant":"123abc",
+              "route":6,
+              "isPublishedFbia":false,
+              "published":true
+            }
+          ]
+        }
+      }
+     """
+    Then the response status code should be 201
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/{version}/packages/6"
+    Then the response status code should be 200
+    And the JSON nodes should contain:
+      | headline                | Richtlinien zum Datenschutz     |
+      | status                  | published                       |
+
+    And I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/api/v1/content/push" with body:
+    """
+     {
+      "readtime":57,
+      "ednote":"In the story \"datenschutz\"  sent at: 29/01/2019 15:35\r\n\r\nThis is corrected repeat.",
+      "copyrightnotice":"",
+      "type":"text",
+      "charcount":113634,
+      "versioncreated":"2019-01-29T15:11:06+0000",
+      "language":"en",
+      "firstpublished":"2019-01-14T09:51:49+0000",
+      "body_html":"<h1>Richtlinien zum Datenschutz</h1>",
+      "copyrightholder":"",
+      "urgency":3,
+      "headline":"Richtlinien zum Datenschutz",
+      "extra":{
+        "seotitle":"Richtlinien zum Datenschutz"
+      },
+      "usageterms":"",
+      "wordcount":14364,
+      "version":"7",
+      "profile":"NachrichtenFG",
+      "pubstatus":"usable",
+      "priority":6,
+      "service":[
+        {
+          "code":"serv",
+          "name":"Service"
+        }
+      ],
+      "firstcreated":"2019-01-14T09:09:56+0000",
+      "slugline":"datenschutz",
+      "annotations":[
+
+      ],
+      "source":"fg",
+      "guid":"dc8fcbb4-22f2-4e0b-bd24-7714ce8d865a"
+    }
+    """
+    Then the response status code should be 201
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v1/packages/6"
+    Then the response status code should be 200
+    And the JSON nodes should contain:
+      | headline                | Richtlinien zum Datenschutz     |
+      | status                  | published                       |
+      | slugline                | datenschutz                     |
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v1/content/articles/6"
+    Then the response status code should be 200
+    And the JSON nodes should contain:
+      | title                   | Richtlinien zum Datenschutz     |
+      | status                  | published                       |
+    And the JSON node "slug" should be equal to "richtlinien-zum-datenschutz"
+
+    And I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "PATCH" request to "/api/v1/settings/" with body:
+    """
+    {
+      "settings": {
+        "name":"override_slug_on_correction",
+        "value":true
+      }
+    }
+    """
+    And I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/api/v1/content/push" with body:
+    """
+     {
+      "readtime":57,
+      "ednote":"In the story \"datenschutz\"  sent at: 29/01/2019 15:35\r\n\r\nThis is corrected repeat.",
+      "copyrightnotice":"",
+      "type":"text",
+      "charcount":113634,
+      "versioncreated":"2019-01-29T15:11:06+0000",
+      "language":"en",
+      "firstpublished":"2019-01-14T09:51:49+0000",
+      "body_html":"<h1>Richtlinien zum Datenschutz</h1>",
+      "copyrightholder":"",
+      "urgency":3,
+      "headline":"Richtlinien zum Datenschutz",
+      "extra":{
+        "seotitle":"Richtlinien zum Datenschutz"
+      },
+      "usageterms":"",
+      "wordcount":14364,
+      "version":"7",
+      "profile":"NachrichtenFG",
+      "pubstatus":"usable",
+      "priority":6,
+      "service":[
+        {
+          "code":"serv",
+          "name":"Service"
+        }
+      ],
+      "firstcreated":"2019-01-14T09:09:56+0000",
+      "slugline":"datenschutz",
+      "annotations":[
+
+      ],
+      "source":"fg",
+      "guid":"dc8fcbb4-22f2-4e0b-bd24-7714ce8d865a"
+    }
+    """
+    Then the response status code should be 201
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v1/packages/6"
+    Then the response status code should be 200
+    And the JSON nodes should contain:
+      | headline                | Richtlinien zum Datenschutz     |
+      | status                  | published                       |
+      | slugline                | datenschutz                     |
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v1/content/articles/6"
+    Then the response status code should be 200
+    And the JSON nodes should contain:
+      | title                   | Richtlinien zum Datenschutz     |
+      | status                  | published                       |
+    And the JSON node "slug" should be equal to "datenschutz"

--- a/features/settings/listing_settings.feature
+++ b/features/settings/listing_settings.feature
@@ -95,6 +95,12 @@ Feature: Checking if settings work correctly
         "name":"use_first_published_as_publish_date"
       },
       {
+        "type": "boolean",
+        "scope": "tenant",
+        "value": false,
+        "name": "override_slug_on_correction"
+      },
+      {
         "label":"Primary Font Family",
         "value":"Roboto",
         "type":"string",

--- a/features/settings/restoring_settings_by_scope.feature
+++ b/features/settings/restoring_settings_by_scope.feature
@@ -94,6 +94,12 @@ Feature: Checking if restoring settings by scope works correctly
         "name":"use_first_published_as_publish_date"
       },
       {
+        "type": "boolean",
+        "scope": "tenant",
+        "value": false,
+        "name": "override_slug_on_correction"
+      },
+      {
         "label":"Primary Font Family",
         "value":"Roboto",
         "type":"string",
@@ -277,6 +283,12 @@ Feature: Checking if restoring settings by scope works correctly
         "name":"use_first_published_as_publish_date"
       },
       {
+        "type": "boolean",
+        "scope": "tenant",
+        "value": false,
+        "name": "override_slug_on_correction"
+      },
+      {
         "label":"Primary Font Family",
         "value":"Oswald",
         "type":"string",
@@ -425,6 +437,12 @@ Feature: Checking if restoring settings by scope works correctly
         "scope":"tenant",
         "value":false,
         "name":"use_first_published_as_publish_date"
+      },
+      {
+        "type": "boolean",
+        "scope": "tenant",
+        "value": false,
+        "name": "override_slug_on_correction"
       },
       {
         "label":"Primary Font Family",

--- a/features/settings/updating_multiple_settings_at_once.feature
+++ b/features/settings/updating_multiple_settings_at_once.feature
@@ -113,6 +113,12 @@ Feature: Settings bulk update
         "name":"use_first_published_as_publish_date"
       },
       {
+        "type": "boolean",
+        "scope": "tenant",
+        "value": false,
+        "name": "override_slug_on_correction"
+      },
+      {
         "label":"Primary Font Family",
         "value":"Lato",
         "type":"string",
@@ -283,6 +289,12 @@ Feature: Settings bulk update
         "name":"use_first_published_as_publish_date"
       },
       {
+        "type": "boolean",
+        "scope": "tenant",
+        "value": false,
+        "name": "override_slug_on_correction"
+      },
+      {
         "label":"Primary Font Family",
         "value":"Lato",
         "type":"string",
@@ -381,14 +393,14 @@ Feature: Settings bulk update
     And I send a "GET" request to "/api/{version}/settings/"
     Then the response status code should be 200
     And the JSON nodes should contain:
-      | [13].name               | primary_font_family                 |
-      | [13].value              | Lato                                |
-      | [14].name               | secondary_font_family               |
+      | [14].name               | primary_font_family                 |
+      | [14].value              | Lato                                |
+      | [15].name               | secondary_font_family               |
       | [15].value              | Oswald                              |
       | [9].name                | theme_logo                          |
       | [9].value               | .png                                |
-      | [15].name               | body_font_size                      |
-      | [15].value              | 16                                  |
+      | [16].name               | body_font_size                      |
+      | [16].value              | 16                                  |
     And I am authenticated as "test.user"
     When I add "Content-Type" header equal to "application/json"
     And I send a "PATCH" request to "/api/{version}/settings/bulk/" with body:
@@ -410,5 +422,5 @@ Feature: Settings bulk update
     And I send a "GET" request to "/api/{version}/settings/"
     Then the response status code should be 200
     And the JSON nodes should contain:
-      | [16].name                | switch   |
-    And the JSON node "[16].value" should be false
+      | [17].name                | switch   |
+    And the JSON node "[17].value" should be false

--- a/src/SWP/Bundle/CoreBundle/EventListener/OverrideArticleSlugListener.php
+++ b/src/SWP/Bundle/CoreBundle/EventListener/OverrideArticleSlugListener.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2019 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2019 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\EventListener;
+
+use SWP\Bundle\ContentBundle\Event\ArticleEvent;
+use SWP\Bundle\SettingsBundle\Manager\SettingsManagerInterface;
+use SWP\Component\MultiTenancy\Context\TenantContextInterface;
+
+final class OverrideArticleSlugListener
+{
+    /**
+     * @var SettingsManagerInterface
+     */
+    private $settingsManager;
+    /**
+     * @var TenantContextInterface
+     */
+    private $tenantContext;
+
+    public function __construct(SettingsManagerInterface $settingsManager, TenantContextInterface $tenantContext)
+    {
+        $this->settingsManager = $settingsManager;
+        $this->tenantContext = $tenantContext;
+    }
+
+    public function overrideSlugIfNeeded(ArticleEvent $event): void
+    {
+        $article = $event->getArticle();
+        $package = $event->getPackage();
+
+        $overrideSlugOnCorrection = $this->settingsManager->get('override_slug_on_correction', 'tenant', $this->tenantContext->getTenant());
+
+        if ($overrideSlugOnCorrection && null !== $article->getSlug()) {
+            $article->setSlug($package->getSlugline());
+        }
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/EventListener/OverrideArticleSlugListener.php
+++ b/src/SWP/Bundle/CoreBundle/EventListener/OverrideArticleSlugListener.php
@@ -26,6 +26,7 @@ final class OverrideArticleSlugListener
      * @var SettingsManagerInterface
      */
     private $settingsManager;
+
     /**
      * @var TenantContextInterface
      */

--- a/src/SWP/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -286,6 +286,10 @@ swp_settings:
             type: boolean
             scope: tenant
             value: false
+        override_slug_on_correction:
+            type: boolean
+            scope: tenant
+            value: false
 
 swp_analytics:
     persistence:

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -753,6 +753,13 @@ services:
             - { name: kernel.event_listener, event: swp.article.pre_create, method: setPublishDate }
             - { name: kernel.event_listener, event: swp.article.pre_update, method: setPublishDate }
 
+    SWP\Bundle\CoreBundle\EventListener\OverrideArticleSlugListener:
+        arguments:
+            - '@swp_settings.manager.settings'
+            - '@swp_multi_tenancy.tenant_context'
+        tags:
+            - { name: kernel.event_listener, event: swp.article.pre_update, method: overrideSlugIfNeeded }
+
     SWP\Bundle\CoreBundle\Service\ArticleStatisticsService:
         public: true
         arguments:


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| Bug fix?                  | no
| New feature?              | yes
| BC breaks?                | no
| Deprecations?             | no
| Tests pass?               | yes
| Changelog update required | yes
| License                   | AGPLv3

By setting `override_slug_on_correction` setting to `true` it is possible to override article's slug on article correction.