### PR TITLE
fix article loader when slug is provided by is empty string

### DIFF
--- a/features/twig/loaders/content_list_items_loader.feature
+++ b/features/twig/loaders/content_list_items_loader.feature
@@ -55,3 +55,11 @@ Feature: Working with Content List Items Loader
       {% endgimme %}
      """
     Then rendered template should not contain "First Test Article"
+
+    And I render a template with content:
+     """
+      {% gimme article with {slug: ""} %}
+        aaa
+      {% endgimme %}
+     """
+    Then rendered template should not contain "aaa"

--- a/src/SWP/Bundle/ContentBundle/Loader/ArticleLoader.php
+++ b/src/SWP/Bundle/ContentBundle/Loader/ArticleLoader.php
@@ -98,9 +98,12 @@ class ArticleLoader extends PaginatedLoader implements LoaderInterface
                 try {
                     return $this->getArticleMeta($parameters['article']);
                 } catch (NotFoundHttpException $e) {
-                    return;
+                    return false;
                 }
             } elseif (array_key_exists('slug', $parameters)) {
+                if ('' === $parameters['slug']) {
+                    $parameters['slug'] = null;
+                }
                 $criteria->set('slug', $parameters['slug']);
             }
 
@@ -109,7 +112,7 @@ class ArticleLoader extends PaginatedLoader implements LoaderInterface
 
                 return $this->getArticleMeta($article);
             } catch (NotFoundHttpException $e) {
-                return;
+                return false;
             }
         } elseif ('articles' === $type && LoaderInterface::COLLECTION === $responseType) {
             $currentPage = $this->context['route'];

--- a/src/SWP/Bundle/ContentBundle/Loader/ArticleLoader.php
+++ b/src/SWP/Bundle/ContentBundle/Loader/ArticleLoader.php
@@ -128,7 +128,7 @@ class ArticleLoader extends PaginatedLoader implements LoaderInterface
 
                     if (null === $route) {
                         // if Route parameter was passed but it was not found - don't return articles not filtered by route
-                        return;
+                        return false;
                     }
                 }
             }
@@ -151,7 +151,6 @@ class ArticleLoader extends PaginatedLoader implements LoaderInterface
             $this->setDateRangeToCriteria($criteria, $parameters);
             $countCriteria = clone $criteria;
             $articlesCollection = $this->articleProvider->getManyByCriteria($criteria, $criteria->get('order', []));
-
             if ($articlesCollection->count() > 0) {
                 $metaCollection = new MetaCollection();
                 $metaCollection->setTotalItemsCount($this->articleProvider->getCountByCriteria($countCriteria));
@@ -161,11 +160,16 @@ class ArticleLoader extends PaginatedLoader implements LoaderInterface
                         $metaCollection->add($articleMeta);
                     }
                 }
+
                 unset($articlesCollection, $route, $criteria);
 
                 return $metaCollection;
             }
+
+            return false;
         }
+
+        return false;
     }
 
     /**
@@ -190,12 +194,14 @@ class ArticleLoader extends PaginatedLoader implements LoaderInterface
     /**
      * @param ArticleInterface|null $article
      *
-     * @return \SWP\Component\TemplatesSystem\Gimme\Meta\Meta|void
+     * @return \SWP\Component\TemplatesSystem\Gimme\Meta\Meta|bool
      */
     protected function getArticleMeta($article)
     {
         if (null !== $article) {
             return $this->metaFactory->create($article);
         }
+
+        return false;
     }
 }

--- a/src/SWP/Bundle/ContentBundle/Provider/ORM/ArticleProvider.php
+++ b/src/SWP/Bundle/ContentBundle/Provider/ORM/ArticleProvider.php
@@ -18,6 +18,8 @@ namespace SWP\Bundle\ContentBundle\Provider\ORM;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use function iterator_to_array;
 use SWP\Component\Common\Criteria\Criteria;
 use SWP\Bundle\ContentBundle\Doctrine\ArticleRepositoryInterface;
 use SWP\Bundle\ContentBundle\Model\ArticleInterface;
@@ -79,12 +81,15 @@ class ArticleProvider implements ArticleProviderInterface
     {
         // set max results to null to not break joins
         $criteria->set('maxResults', null);
-        $article = $this->articleRepository->getByCriteria($criteria, [])->getQuery()->getResult();
-        if (null === $article || 0 === count($article)) {
+        $query = $this->articleRepository->getByCriteria($criteria, [])->getQuery();
+        $query->setMaxResults(1);
+        $query->setFirstResult(0);
+        $articles = iterator_to_array(new Paginator($query, $fetchJoin = true));
+        if (null === $articles || 0 === count($articles)) {
             throw new NotFoundHttpException('Article was not found');
         }
 
-        return $article[0];
+        return $articles[0];
     }
 
     /**

--- a/src/SWP/Bundle/ContentBundle/Tests/Functional/Loader/ArticleLoaderTest.php
+++ b/src/SWP/Bundle/ContentBundle/Tests/Functional/Loader/ArticleLoaderTest.php
@@ -58,12 +58,12 @@ class ArticleLoaderTest extends WebTestCase
         $article = $this->articleLoader->load('article', ['slug' => 'test-article']);
         $this->assertInstanceOf('SWP\Component\TemplatesSystem\Gimme\Meta\Meta', $article);
 
-        $this->assertNull($this->articleLoader->load('article', ['slug' => 'test-articles']));
-        $this->assertNull($this->articleLoader->load('article', ['slug' => 'test-article'], [], LoaderInterface::COLLECTION));
+        $this->assertFalse($this->articleLoader->load('article', ['slug' => 'test-articles']));
+        $this->assertFalse($this->articleLoader->load('article', ['slug' => 'test-article'], [], LoaderInterface::COLLECTION));
         $this->assertTrue(3 == count($this->articleLoader->load('articles', ['route' => '/news'], [], LoaderInterface::COLLECTION)));
-        $this->assertNull($this->articleLoader->load('articles', ['route' => 99], [], LoaderInterface::COLLECTION));
+        $this->assertFalse($this->articleLoader->load('articles', ['route' => 99], [], LoaderInterface::COLLECTION));
 
-        $this->assertNull($this->articleLoader->load('article', [], [], LoaderInterface::COLLECTION));
+        $this->assertFalse($this->articleLoader->load('article', [], [], LoaderInterface::COLLECTION));
     }
 
     public function testLoadWithParameters()

--- a/src/SWP/Bundle/CoreBundle/Checker/AmpSupportChecker.php
+++ b/src/SWP/Bundle/CoreBundle/Checker/AmpSupportChecker.php
@@ -56,6 +56,6 @@ final class AmpSupportChecker implements AmpSupportCheckerInterface
             return false;
         }
 
-        return null !== $request->attributes->get(RouteEnhancer::ARTICLE_META, null) || 'swp_package_preview' === $request->attributes->get('_route');
+        return false !== $request->attributes->get(RouteEnhancer::ARTICLE_META, false) || 'swp_package_preview' === $request->attributes->get('_route');
     }
 }

--- a/src/SWP/Bundle/CoreBundle/Enhancer/RouteEnhancer.php
+++ b/src/SWP/Bundle/CoreBundle/Enhancer/RouteEnhancer.php
@@ -109,17 +109,17 @@ class RouteEnhancer implements RouteEnhancerInterface
      */
     public function setArticleMeta($content, array $defaults)
     {
-        $articleMeta = null;
+        $articleMeta = false;
         if (isset($defaults['slug'])) {
             $articleMeta = $this->metaLoader->load('article', ['slug' => $defaults['slug']], LoaderInterface::SINGLE);
             $defaults['type'] = RouteInterface::TYPE_COLLECTION;
-            if (null === $articleMeta || ($articleMeta->getValues()->getRoute()->getId() !== $defaults[RouteObjectInterface::ROUTE_OBJECT]->getId())) {
+            if (false === $articleMeta || ($articleMeta->getValues()->getRoute()->getId() !== $defaults[RouteObjectInterface::ROUTE_OBJECT]->getId())) {
                 throw new NotFoundHttpException(sprintf('Article for slug: %s was not found.', $defaults['slug']));
             }
         } elseif ($content instanceof ArticleInterface) {
             $articleMeta = $this->metaLoader->load('article', ['article' => $content], LoaderInterface::SINGLE);
             $defaults['type'] = RouteInterface::TYPE_CONTENT;
-            if (null === $articleMeta) {
+            if (false === $articleMeta) {
                 throw new NotFoundHttpException(sprintf('Content with id: %s was not found.', $content->getId()));
             }
         }


### PR DESCRIPTION
  - [x] Bug fix
  - [ ] New feature
  - [ ] BC breaks
  - [ ] Deprecations
  - [ ] Changelog update (if required)

Fixed tickets : 
License: AGPLv3
