### PR TITLE
Empty value for theme setting of type 'string' cannot be saved

### DIFF
--- a/features/settings/updating_multiple_settings_at_once.feature
+++ b/features/settings/updating_multiple_settings_at_once.feature
@@ -452,3 +452,26 @@ Feature: Settings bulk update
     And the JSON nodes should contain:
       | [20].name                | switch   |
     And the JSON node "[20].value" should be false
+
+    And I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "PATCH" request to "/api/v2/settings/bulk/" with body:
+    """
+    {
+      "bulk":[
+        {
+          "name":"primary_font_family",
+          "value":""
+        }
+      ]
+    }
+    """
+    Then the response status code should be 200
+
+    And I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "GET" request to "/api/v2/settings/"
+    Then the response status code should be 200
+    And the JSON nodes should contain:
+      | [17].name               | primary_font_family   |
+    And the JSON node "[17].value" should be equal to ""

--- a/src/SWP/Bundle/SettingsBundle/Manager/SettingsManager.php
+++ b/src/SWP/Bundle/SettingsBundle/Manager/SettingsManager.php
@@ -286,6 +286,10 @@ class SettingsManager implements SettingsManagerInterface
      */
     private function encodeValue($settingType, $value)
     {
+        if ('string' === $settingType) {
+            return (string) $value;
+        }
+
         if (($actualType = gettype($value)) !== $settingType) {
             throw new \Exception(sprintf('Value type should be "%s" not "%s"', $settingType, $actualType));
         }

--- a/src/SWP/Bundle/SettingsBundle/Tests/Functional/Controller/SettingsControllerTest.php
+++ b/src/SWP/Bundle/SettingsBundle/Tests/Functional/Controller/SettingsControllerTest.php
@@ -79,6 +79,14 @@ class SettingsControllerTest extends WebTestCase
                 'value' => '1234567',
         ]);
 
-        $this->assertEquals(500, $client->getResponse()->getStatusCode());
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $client = static::createClient([], ['PHP_AUTH_USER' => 'publisher', 'PHP_AUTH_PW' => 'testpass']);
+        $client->request('PATCH', $this->router->generate('swp_api_settings_update'), [
+            'name' => 'third_setting',
+            'value' => false,
+        ]);
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }
 }

--- a/src/SWP/Component/Seo/Model/SeoMetadata.php
+++ b/src/SWP/Component/Seo/Model/SeoMetadata.php
@@ -77,7 +77,7 @@ class SeoMetadata implements SeoMetadataInterface
         $this->id = $id;
     }
 
-    public function getId(): string
+    public function getId()
     {
         return $this->id;
     }


### PR DESCRIPTION
  - [x] Bug fix
  - [ ] New feature
  - [ ] BC breaks
  - [ ] Deprecations
  - [ ] Changelog update (if required)

Fixed tickets : BN-439
License: AGPLv3
