### PR TITLE
impressions performance improvements

### DIFF
--- a/features/02_articles/analytics.feature
+++ b/features/02_articles/analytics.feature
@@ -18,7 +18,7 @@ Feature: Collect article statistics
     And I add "Referer" header equal to "http://localhost/news/test-news-article"
     When I send a POST request to "/_swp_analytics?type=impression&15362257892160.335822969944755" with body:
     """
-      ["http://localhost/news/test-news-article", "http://facebook.com"]
+      ["http://localhost/news", "http://localhost/news/test-news-article", "http://example.com"]
     """
     Then the response status code should be 200
     And the header "terminate-immediately" should be equal to "1"

--- a/src/SWP/Bundle/CoreBundle/Consumer/AnalyticsEventConsumer.php
+++ b/src/SWP/Bundle/CoreBundle/Consumer/AnalyticsEventConsumer.php
@@ -159,13 +159,6 @@ final class AnalyticsEventConsumer implements ConsumerInterface
         $this->articleStatisticsObjectManager->getConnection()->beginTransaction();
 
         try {
-            try {
-                $stmt = $this->articleStatisticsObjectManager->getConnection()->prepare('LOCK TABLE swp_article_statistics IN EXCLUSIVE MODE;');
-                $stmt->execute();
-            } catch (\Exception $e) {
-                // ignore when lock not supported
-            }
-
             $ids = [];
             foreach ($articles as $articleId) {
                 $articleStatistics = $this->articleStatisticsService->addArticleEvent(
@@ -176,6 +169,13 @@ final class AnalyticsEventConsumer implements ConsumerInterface
 
                 $ids[] = $articleStatistics->getId();
                 echo 'Article '.$articleId." impression was added \n";
+            }
+
+            try {
+                $stmt = $this->articleStatisticsObjectManager->getConnection()->prepare('LOCK TABLE swp_article_statistics IN EXCLUSIVE MODE;');
+                $stmt->execute();
+            } catch (\Exception $e) {
+                // ignore when lock not supported
             }
 
             $query = $this->articleStatisticsObjectManager->createQuery('UPDATE '.ArticleStatistics::class.' s SET s.impressionsNumber = s.impressionsNumber + 1 WHERE s.id IN (:ids)');

--- a/src/SWP/Bundle/CoreBundle/Consumer/AnalyticsEventConsumer.php
+++ b/src/SWP/Bundle/CoreBundle/Consumer/AnalyticsEventConsumer.php
@@ -157,6 +157,7 @@ final class AnalyticsEventConsumer implements ConsumerInterface
         $impressionSource = $this->getImpressionSource($request);
 
         $this->articleStatisticsObjectManager->getConnection()->beginTransaction();
+
         try {
             try {
                 $stmt = $this->articleStatisticsObjectManager->getConnection()->prepare('LOCK TABLE swp_article_statistics IN EXCLUSIVE MODE;');
@@ -181,6 +182,7 @@ final class AnalyticsEventConsumer implements ConsumerInterface
             $this->articleStatisticsObjectManager->getConnection()->commit();
         } catch (\Exception $e) {
             $this->articleStatisticsObjectManager->getConnection()->rollBack();
+
             throw $e;
         }
     }

--- a/src/SWP/Bundle/CoreBundle/Consumer/AnalyticsEventConsumer.php
+++ b/src/SWP/Bundle/CoreBundle/Consumer/AnalyticsEventConsumer.php
@@ -166,18 +166,22 @@ final class AnalyticsEventConsumer implements ConsumerInterface
                 // ignore when lock not supported
             }
 
+            $ids = [];
             foreach ($articles as $articleId) {
                 $articleStatistics = $this->articleStatisticsService->addArticleEvent(
                     (int) $articleId,
                     ArticleEventInterface::ACTION_IMPRESSION,
                     $impressionSource
                 );
-                $query = $this->articleStatisticsObjectManager->createQuery('UPDATE '.ArticleStatistics::class.' s SET s.impressionsNumber = s.impressionsNumber + 1 WHERE s.id = :id');
-                $query->setParameter('id', $articleStatistics->getId());
-                $query->execute();
 
+                $ids[] = $articleStatistics->getId();
                 echo 'Article '.$articleId." impression was added \n";
             }
+
+            $query = $this->articleStatisticsObjectManager->createQuery('UPDATE '.ArticleStatistics::class.' s SET s.impressionsNumber = s.impressionsNumber + 1 WHERE s.id IN (:ids)');
+            $query->setParameter('ids', $ids);
+            $query->execute();
+
             $this->articleStatisticsObjectManager->flush();
             $this->articleStatisticsObjectManager->getConnection()->commit();
         } catch (\Exception $e) {

--- a/src/SWP/Bundle/CoreBundle/Resolver/ArticleResolver.php
+++ b/src/SWP/Bundle/CoreBundle/Resolver/ArticleResolver.php
@@ -38,8 +38,8 @@ class ArticleResolver implements ArticleResolverInterface
 
     public function resolve(string $url): ?ArticleInterface
     {
-        $collectionRouteCacheKey = md5('route_'.md5($url));
-        $articleCacheKey = md5('article_'.md5($url));
+        $collectionRouteCacheKey = md5('route_'.$url);
+        $articleCacheKey = md5('article_'.$url);
 
         if ($this->cacheProvider->contains($articleCacheKey)) {
             return $this->cacheProvider->fetch($articleCacheKey);

--- a/src/SWP/Bundle/CoreBundle/Resolver/ArticleResolver.php
+++ b/src/SWP/Bundle/CoreBundle/Resolver/ArticleResolver.php
@@ -41,7 +41,7 @@ class ArticleResolver implements ArticleResolverInterface
         $collectionRouteCacheKey = md5('route_'.md5($url));
         $articleCacheKey = md5('article_'.md5($url));
 
-        if ($this->cacheProvider->contains($collectionRouteCacheKey)) {
+        if ($this->cacheProvider->contains($articleCacheKey)) {
             return $this->cacheProvider->fetch($articleCacheKey);
         }
 

--- a/src/SWP/Bundle/CoreBundle/Resolver/ArticleResolver.php
+++ b/src/SWP/Bundle/CoreBundle/Resolver/ArticleResolver.php
@@ -39,11 +39,6 @@ class ArticleResolver implements ArticleResolverInterface
     public function resolve(string $url): ?ArticleInterface
     {
         $collectionRouteCacheKey = md5('route_'.$url);
-        $articleCacheKey = md5('article_'.$url);
-
-        if ($this->cacheProvider->contains($articleCacheKey)) {
-            return $this->cacheProvider->fetch($articleCacheKey);
-        }
 
         if ($this->cacheProvider->contains($collectionRouteCacheKey)) {
             return null;
@@ -53,8 +48,6 @@ class ArticleResolver implements ArticleResolverInterface
             $route = $this->matcher->match($this->getFragmentFromUrl($url, 'path'));
 
             if (isset($route['_article_meta']) && $route['_article_meta'] instanceof Meta && ($article = $route['_article_meta']->getValues()) instanceof ArticleInterface) {
-                $this->cacheProvider->save($articleCacheKey, $article);
-
                 return $article;
             }
 

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -577,6 +577,7 @@ services:
             - '@router'
             - '@swp.resolver.article'
             - '@swp.object_manager.article_statistics'
+            - '@doctrine_cache.providers.main_cache'
 
     SWP\Bundle\CoreBundle\Consumer\ContentPushConsumer:
         arguments:

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -787,3 +787,4 @@ services:
             - '@swp.repository.article_events'
             - '@swp.factory.article_statistics'
             - '@swp.factory.article_events'
+            - '@swp.object_manager.article'

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -763,6 +763,7 @@ services:
         public: true
         arguments:
             - '@router'
+            - '@doctrine_cache.providers.main_cache'
 
     SWP\Bundle\CoreBundle\EventListener\SetArticlePublishDateListener:
         arguments:

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -576,6 +576,7 @@ services:
             - '@swp_multi_tenancy.tenant_context'
             - '@router'
             - '@swp.resolver.article'
+            - '@swp.object_manager.article_statistics'
 
     SWP\Bundle\CoreBundle\Consumer\ContentPushConsumer:
         arguments:

--- a/src/SWP/Bundle/CoreBundle/Service/ArticleStatisticsService.php
+++ b/src/SWP/Bundle/CoreBundle/Service/ArticleStatisticsService.php
@@ -159,7 +159,7 @@ class ArticleStatisticsService implements ArticleStatisticsServiceInterface
         $articleEvent->setImpressionRoute($sourceRoute);
         $articleEvent->setImpressionType($type);
         $articleStatistics->setImpressionsNumber($this->articleEventRepository->getCountForArticleAllImpressions($article) + 1);
-        $this->articleStatisticsRepository->add($articleStatistics);
+        $this->articleStatisticsRepository->persist($articleStatistics);
     }
 
     private function getArticleEvent(

--- a/src/SWP/Bundle/CoreBundle/Service/ArticleStatisticsService.php
+++ b/src/SWP/Bundle/CoreBundle/Service/ArticleStatisticsService.php
@@ -127,7 +127,7 @@ class ArticleStatisticsService implements ArticleStatisticsServiceInterface
 
         $articleEvent = $this->getArticleEvent($articleStatistics, $article, ArticleEventInterface::ACTION_PAGEVIEW);
         $articleEvent->setPageViewSource($pageViewSource);
-        $articleStatistics->setPageViewsNumber($this->articleEventRepository->getCountForArticleAllPageViews($article) + 1);
+
         if (ArticleEventInterface::PAGEVIEW_SOURCE_INTERNAL === $pageViewSource) {
             $internalPageViewsCount = $this->articleEventRepository->getCountForArticleInternalPageViews($article) + 1;
             if ($internalPageViewsCount > 0 && $articleStatistics->getImpressionsNumber() > 0) {
@@ -158,7 +158,6 @@ class ArticleStatisticsService implements ArticleStatisticsServiceInterface
         $articleEvent->setImpressionArticle($sourceArticle);
         $articleEvent->setImpressionRoute($sourceRoute);
         $articleEvent->setImpressionType($type);
-        $articleStatistics->setImpressionsNumber($this->articleEventRepository->getCountForArticleAllImpressions($article) + 1);
         $this->articleStatisticsRepository->persist($articleStatistics);
     }
 

--- a/src/SWP/Bundle/CoreBundle/Service/ArticleStatisticsService.php
+++ b/src/SWP/Bundle/CoreBundle/Service/ArticleStatisticsService.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace SWP\Bundle\CoreBundle\Service;
 
+use Doctrine\Common\Persistence\ObjectManager;
 use SWP\Bundle\AnalyticsBundle\Model\ArticleEventInterface;
 use SWP\Bundle\AnalyticsBundle\Model\ArticleStatisticsInterface;
 use SWP\Bundle\AnalyticsBundle\Repository\ArticleEventRepositoryInterface;
@@ -23,6 +24,7 @@ use SWP\Bundle\AnalyticsBundle\Services\ArticleStatisticsServiceInterface;
 use SWP\Bundle\ContentBundle\Doctrine\ArticleRepositoryInterface;
 use SWP\Bundle\ContentBundle\Model\ArticleInterface;
 use SWP\Bundle\ContentBundle\Model\RouteInterface;
+use SWP\Bundle\CoreBundle\Model\Article;
 use SWP\Component\Storage\Factory\FactoryInterface;
 use SWP\Component\Storage\Repository\RepositoryInterface;
 
@@ -56,18 +58,22 @@ class ArticleStatisticsService implements ArticleStatisticsServiceInterface
      */
     protected $articleEventFactory;
 
+    protected $articleObjectManager;
+
     public function __construct(
         ArticleRepositoryInterface $articleRepository,
         RepositoryInterface $articleStatisticsRepository,
         ArticleEventRepositoryInterface $articleEventRepository,
         FactoryInterface $articleStatisticsFactory,
-        FactoryInterface $articleEventFactory
+        FactoryInterface $articleEventFactory,
+        ObjectManager $articleObjectManager
     ) {
         $this->articleRepository = $articleRepository;
         $this->articleStatisticsRepository = $articleStatisticsRepository;
         $this->articleEventRepository = $articleEventRepository;
         $this->articleStatisticsFactory = $articleStatisticsFactory;
         $this->articleEventFactory = $articleEventFactory;
+        $this->articleObjectManager = $articleObjectManager;
     }
 
     public function addArticleEvent(int $articleId, string $action, array $extraData): ArticleStatisticsInterface
@@ -82,13 +88,13 @@ class ArticleStatisticsService implements ArticleStatisticsServiceInterface
                 $sourceArticle = null;
                 $sourceRoute = null;
                 $type = null;
-                if (array_key_exists(ArticleStatisticsServiceInterface::KEY_IMPRESSION_SOURCE_ARTICLE, $extraData)) {
+                if (isset($extraData[ArticleStatisticsServiceInterface::KEY_IMPRESSION_SOURCE_ARTICLE])) {
                     $sourceArticle = $extraData[ArticleStatisticsServiceInterface::KEY_IMPRESSION_SOURCE_ARTICLE];
                 }
-                if (array_key_exists(ArticleStatisticsServiceInterface::KEY_IMPRESSION_SOURCE_ROUTE, $extraData)) {
+                if (isset($extraData[ArticleStatisticsServiceInterface::KEY_IMPRESSION_SOURCE_ROUTE])) {
                     $sourceRoute = $extraData[ArticleStatisticsServiceInterface::KEY_IMPRESSION_SOURCE_ROUTE];
                 }
-                if (array_key_exists(ArticleStatisticsServiceInterface::KEY_IMPRESSION_TYPE, $extraData)) {
+                if (isset($extraData[ArticleStatisticsServiceInterface::KEY_IMPRESSION_TYPE])) {
                     $type = $extraData[ArticleStatisticsServiceInterface::KEY_IMPRESSION_TYPE];
                 }
                 $this->addNewImpressionEvent($articleStatistics, $articleId, $sourceArticle, $sourceRoute, $type);
@@ -114,7 +120,7 @@ class ArticleStatisticsService implements ArticleStatisticsServiceInterface
     protected function addNewPageViewEvent(ArticleStatisticsInterface $articleStatistics, int $articleId, string $pageViewSource): void
     {
         /** @var ArticleInterface $article */
-        $article = $this->articleRepository->findOneBy(['id' => $articleId]);
+        $article = $this->articleObjectManager->getReference(ArticleInterface::class, $articleId);
         if (null === $article) {
             return;
         }
@@ -143,7 +149,7 @@ class ArticleStatisticsService implements ArticleStatisticsServiceInterface
         string $type = null
     ): void {
         /** @var ArticleInterface $article */
-        $article = $this->articleRepository->findOneBy(['id' => $articleId]);
+        $article = $this->articleObjectManager->getReference(ArticleInterface::class, $articleId);
         if (null === $article) {
             return;
         }

--- a/src/SWP/Bundle/CoreBundle/Tests/Twig/ArticleEventsExtensionTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Twig/ArticleEventsExtensionTest.php
@@ -38,19 +38,86 @@ class ArticleEventsExtensionTest extends WebTestCase
     public function testRenderLinkImpressionCount()
     {
         $this->assertEquals("<script type=\"text/javascript\">
-let arr = [], links = [], l = document.links;
+function isInCurrentViewport(el) {
+    const rect = el.getBoundingClientRect();
+
+    return (
+        rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+        rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
+}
+
+
+let arr = [], links = [], processedLinks = [], l = document.links;
 const hostname = window.location.hostname;
+var iterator = 0;
+var breakpoint = 200;
 
-for(var i=0; i<l.length; i++) {const parts = l[i].pathname.split('/');if (parts.length > 2) {links.push(l[i])}}
-for(var i=0; i<links.length; i++) {const attr = links[i].dataset['article'];if(typeof attr !== 'undefined' && arr.indexOf(attr) === -1){arr.push(attr); links.splice(i, 1);}}
-for(var i=0; i<links.length; i++){if(arr.indexOf(links[i].href) === -1 && links[i].href.indexOf(hostname) !== -1){arr.push(links[i].href);}}
+var process = function process() {
+  links = [];
+  arr = [];
+  // filter out section pages
+  for(let i=0; i<l.length; i++) {
+      const parts = l[i].pathname.split('/');
+      if (parts.length > 2 && isInCurrentViewport(l[i]) && processedLinks.indexOf(l[i].href) === -1) {
+          links.push(l[i]);
+      }
+  }
+  // filter out links with data-article, add article id
+  for(let i=0; i<links.length; i++) {
+      const attr = links[i].dataset['article'];
+      // if attribute not in array
+      if(typeof attr !== 'undefined' && arr.indexOf(attr) === -1 && isInCurrentViewport(links[i]) && processedLinks.indexOf(links[i].href) === -1){
+          arr.push(attr); 
+          links.splice(i, 1);
+      }
+  }
+  
+  // filter out links different than current domain
+  for(let i=0; i<links.length; i++){
+      if(arr.indexOf(links[i].href) === -1 && links[i].href.indexOf(hostname) !== -1){
+          arr.push(links[i].href);
+      }
+  }
 
-var xhr = new XMLHttpRequest();
-var read_date = new Date();
-var request_randomizer = \"&\" + read_date.getTime() + Math.random();
-xhr.open('POST', '/_swp_analytics?type=impression'+request_randomizer);
-xhr.setRequestHeader(\"Content-Type\", \"application/json\");
-xhr.send(JSON.stringify(arr));
+  processedLinks = unique(processedLinks.concat(arr));
+  
+  if (arr.length > 0) {
+      let xhr = new XMLHttpRequest();
+      let read_date = new Date();
+      let request_randomizer = \"&\" + read_date.getTime() + Math.random();
+      xhr.open('POST', '/_swp_analytics?type=impression'+request_randomizer);
+      xhr.setRequestHeader(\"Content-Type\", \"application/json\");
+      xhr.send(JSON.stringify(arr));
+  }
+}
+
+var countImpressions = function countImpressions() {
+    let scrollDown = document.body.scrollTop || document.documentElement.scrollTop;
+    if (scrollDown >= breakpoint) {
+       process();
+       breakpoint += 200;
+       iterator++;
+    }
+}
+
+var unique = function unique(array) {
+    let a = array.concat();
+    for(let i=0; i<a.length; ++i) {
+        for(let j=i+1; j<a.length; ++j) {
+            if(a[i] === a[j])
+                a.splice(j--, 1);
+        }
+    }
+
+    return a;
+}
+
+window.onscroll = function() {countImpressions()};
+process();
+
 </script>", $this->getRendered('{{ countArticlesImpressions() }}'));
     }
 

--- a/src/SWP/Bundle/CoreBundle/Twig/ArticleEventsExtension.php
+++ b/src/SWP/Bundle/CoreBundle/Twig/ArticleEventsExtension.php
@@ -51,7 +51,7 @@ class ArticleEventsExtension extends AbstractExtension
         $jsTemplate = <<<'EOT'
 <script type="text/javascript">
 function isInCurrentViewport(el) {
-    var rect = el.getBoundingClientRect();
+    const rect = el.getBoundingClientRect();
 
     return (
         rect.top >= 0 &&
@@ -64,48 +64,21 @@ function isInCurrentViewport(el) {
 
 let arr = [], links = [], processedLinks = [], l = document.links;
 const hostname = window.location.hostname;
-
-window.onscroll = function() {countImpressions()};
-
 var iterator = 0;
 var breakpoint = 200;
 
-function countImpressions() {
-    var scrollDown = document.body.scrollTop || document.documentElement.scrollTop;
-    if (scrollDown >= breakpoint) {
-       process();
-       breakpoint += 200;
-       iterator++;
-    }
-}
-
-function unique(array) {
-    var a = array.concat();
-    for(var i=0; i<a.length; ++i) {
-        for(var j=i+1; j<a.length; ++j) {
-            if(a[i] === a[j])
-                a.splice(j--, 1);
-        }
-    }
-
-    return a;
-}
-
-process();
-
-function process() {
+var process = function process() {
   links = [];
   arr = [];
-  console.log(processedLinks);
   // filter out section pages
-  for(var i=0; i<l.length; i++) {
+  for(let i=0; i<l.length; i++) {
       const parts = l[i].pathname.split('/');
       if (parts.length > 2 && isInCurrentViewport(l[i]) && processedLinks.indexOf(l[i].href) === -1) {
           links.push(l[i]);
       }
   }
   // filter out links with data-article, add article id
-  for(var i=0; i<links.length; i++) {
+  for(let i=0; i<links.length; i++) {
       const attr = links[i].dataset['article'];
       // if attribute not in array
       if(typeof attr !== 'undefined' && arr.indexOf(attr) === -1 && isInCurrentViewport(links[i]) && processedLinks.indexOf(links[i].href) === -1){
@@ -115,7 +88,7 @@ function process() {
   }
   
   // filter out links different than current domain
-  for(var i=0; i<links.length; i++){
+  for(let i=0; i<links.length; i++){
       if(arr.indexOf(links[i].href) === -1 && links[i].href.indexOf(hostname) !== -1){
           arr.push(links[i].href);
       }
@@ -124,14 +97,38 @@ function process() {
   processedLinks = unique(processedLinks.concat(arr));
   
   if (arr.length > 0) {
-      var xhr = new XMLHttpRequest();
-      var read_date = new Date();
-      var request_randomizer = "&" + read_date.getTime() + Math.random();
+      let xhr = new XMLHttpRequest();
+      let read_date = new Date();
+      let request_randomizer = "&" + read_date.getTime() + Math.random();
       xhr.open('POST', '/_swp_analytics?type=impression'+request_randomizer);
       xhr.setRequestHeader("Content-Type", "application/json");
       xhr.send(JSON.stringify(arr));
   }
 }
+
+var countImpressions = function countImpressions() {
+    let scrollDown = document.body.scrollTop || document.documentElement.scrollTop;
+    if (scrollDown >= breakpoint) {
+       process();
+       breakpoint += 200;
+       iterator++;
+    }
+}
+
+var unique = function unique(array) {
+    let a = array.concat();
+    for(let i=0; i<a.length; ++i) {
+        for(let j=i+1; j<a.length; ++j) {
+            if(a[i] === a[j])
+                a.splice(j--, 1);
+        }
+    }
+
+    return a;
+}
+
+window.onscroll = function() {countImpressions()};
+process();
 
 </script>
 EOT;

--- a/src/SWP/Bundle/CoreBundle/spec/Consumer/AnalyticsEventConsumerSpec.php
+++ b/src/SWP/Bundle/CoreBundle/spec/Consumer/AnalyticsEventConsumerSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\SWP\Bundle\CoreBundle\Consumer;
 
+use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Persistence\ObjectManager;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use PhpAmqpLib\Message\AMQPMessage;
 use Prophecy\Argument;
-use SWP\Bundle\AnalyticsBundle\Model\ArticleEventInterface;
 use SWP\Bundle\AnalyticsBundle\Services\ArticleStatisticsServiceInterface;
 use SWP\Bundle\CoreBundle\Consumer\AnalyticsEventConsumer;
 use PhpSpec\ObjectBehavior;
@@ -15,59 +15,17 @@ use SWP\Bundle\CoreBundle\Model\TenantInterface;
 use SWP\Bundle\CoreBundle\Resolver\ArticleResolverInterface;
 use SWP\Component\MultiTenancy\Context\TenantContextInterface;
 use SWP\Component\MultiTenancy\Resolver\TenantResolver;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 
 class AnalyticsEventConsumerSpec extends ObjectBehavior
 {
-    public function it_is_initializable(ArticleStatisticsServiceInterface $articleStatisticsService, TenantResolver $tenantResolver, TenantContextInterface $tenantContext, UrlMatcherInterface $matcher, ArticleResolverInterface $articleResolver, ObjectManager $articleStatisticsObjectManager)
+    public function it_is_initializable(ArticleStatisticsServiceInterface $articleStatisticsService, TenantResolver $tenantResolver, TenantContextInterface $tenantContext, UrlMatcherInterface $matcher, ArticleResolverInterface $articleResolver, ObjectManager $articleStatisticsObjectManager, CacheProvider $cacheProvider)
     {
-        $this->beConstructedWith($articleStatisticsService, $tenantResolver, $tenantContext, $matcher, $articleResolver, $articleStatisticsObjectManager);
+        $this->beConstructedWith($articleStatisticsService, $tenantResolver, $tenantContext, $matcher, $articleResolver, $articleStatisticsObjectManager, $cacheProvider);
         $this->shouldHaveType(AnalyticsEventConsumer::class);
     }
 
-    public function it_executes(ArticleStatisticsServiceInterface $articleStatisticsService, TenantResolver $tenantResolver, TenantContextInterface $tenantContext, TenantInterface $tenant, AMQPMessage $AMQPMessage, UrlMatcherInterface $matcher, ArticleResolverInterface $articleResolver)
-    {
-        $tenantResolver->resolve(Argument::type('string'))->willReturn($tenant);
-        $articleStatisticsService->addArticleEvent(1, 'pageview', [
-            ArticleStatisticsServiceInterface::KEY_PAGEVIEW_SOURCE => ArticleEventInterface::PAGEVIEW_SOURCE_EXTERNAL,
-        ])->shouldBeCalled();
-
-        $tenant = new Tenant();
-        $tenant->setDomainName('localhost');
-        $tenantContext->getTenant()->willReturn($tenant);
-        $tenantContext->setTenant(Argument::any())->shouldBeCalled();
-
-        $this->beConstructedWith($articleStatisticsService, $tenantResolver, $tenantContext, $matcher, $articleResolver);
-
-        $request = new Request();
-        $request->query->set('articleId', 1);
-        $AMQPMessage->getBody()->willReturn(serialize($request));
-        $this->execute($AMQPMessage)->shouldReturn(ConsumerInterface::MSG_ACK);
-    }
-
-    public function it_creates_internal_pageview_event(ArticleStatisticsServiceInterface $articleStatisticsService, TenantResolver $tenantResolver, TenantContextInterface $tenantContext, TenantInterface $tenant, AMQPMessage $AMQPMessage, UrlMatcherInterface $matcher, ArticleResolverInterface $articleResolver)
-    {
-        $tenantResolver->resolve(Argument::type('string'))->willReturn($tenant);
-        $articleStatisticsService->addArticleEvent(1, 'pageview', [
-            ArticleStatisticsServiceInterface::KEY_PAGEVIEW_SOURCE => ArticleEventInterface::PAGEVIEW_SOURCE_INTERNAL,
-        ])->shouldBeCalled();
-
-        $tenant = new Tenant();
-        $tenant->setDomainName('localhost');
-        $tenantContext->getTenant()->willReturn($tenant);
-        $tenantContext->setTenant(Argument::any())->shouldBeCalled();
-
-        $this->beConstructedWith($articleStatisticsService, $tenantResolver, $tenantContext, $matcher, $articleResolver);
-
-        $request = new Request();
-        $request->query->set('articleId', 1);
-        $request->query->set('ref', 'http://localhost/');
-        $AMQPMessage->getBody()->willReturn(serialize($request));
-        $this->execute($AMQPMessage)->shouldReturn(ConsumerInterface::MSG_ACK);
-    }
-
-    public function it_stop_execution_on_invalid_data(ArticleStatisticsServiceInterface $articleStatisticsService, TenantResolver $tenantResolver, TenantContextInterface $tenantContext, TenantInterface $tenant, AMQPMessage $AMQPMessage, UrlMatcherInterface $matcher, ArticleResolverInterface $articleResolver)
+    public function it_stop_execution_on_invalid_data(ArticleStatisticsServiceInterface $articleStatisticsService, TenantResolver $tenantResolver, TenantContextInterface $tenantContext, TenantInterface $tenant, AMQPMessage $AMQPMessage, UrlMatcherInterface $matcher, ArticleResolverInterface $articleResolver, ObjectManager $articleStatisticsObjectManager, CacheProvider $cacheProvider)
     {
         $tenantResolver->resolve(Argument::type('string'))->willReturn($tenant);
         $articleStatisticsService->addArticleEvent(1, 'pageview', [])->shouldNotBeCalled();
@@ -76,7 +34,7 @@ class AnalyticsEventConsumerSpec extends ObjectBehavior
         $tenant->setDomainName('localhost');
         $tenantContext->getTenant()->willReturn($tenant);
 
-        $this->beConstructedWith($articleStatisticsService, $tenantResolver, $tenantContext, $matcher, $articleResolver);
+        $this->beConstructedWith($articleStatisticsService, $tenantResolver, $tenantContext, $matcher, $articleResolver, $articleStatisticsObjectManager, $cacheProvider);
 
         $AMQPMessage->getBody()->willReturn(serialize([]));
         $this->execute($AMQPMessage)->shouldReturn(ConsumerInterface::MSG_REJECT);

--- a/src/SWP/Bundle/CoreBundle/spec/Consumer/AnalyticsEventConsumerSpec.php
+++ b/src/SWP/Bundle/CoreBundle/spec/Consumer/AnalyticsEventConsumerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\SWP\Bundle\CoreBundle\Consumer;
 
+use Doctrine\Common\Persistence\ObjectManager;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use PhpAmqpLib\Message\AMQPMessage;
 use Prophecy\Argument;
@@ -19,9 +20,9 @@ use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 
 class AnalyticsEventConsumerSpec extends ObjectBehavior
 {
-    public function it_is_initializable(ArticleStatisticsServiceInterface $articleStatisticsService, TenantResolver $tenantResolver, TenantContextInterface $tenantContext, UrlMatcherInterface $matcher, ArticleResolverInterface $articleResolver)
+    public function it_is_initializable(ArticleStatisticsServiceInterface $articleStatisticsService, TenantResolver $tenantResolver, TenantContextInterface $tenantContext, UrlMatcherInterface $matcher, ArticleResolverInterface $articleResolver, ObjectManager $articleStatisticsObjectManager)
     {
-        $this->beConstructedWith($articleStatisticsService, $tenantResolver, $tenantContext, $matcher, $articleResolver);
+        $this->beConstructedWith($articleStatisticsService, $tenantResolver, $tenantContext, $matcher, $articleResolver, $articleStatisticsObjectManager);
         $this->shouldHaveType(AnalyticsEventConsumer::class);
     }
 


### PR DESCRIPTION
  - [ ] Bug fix
  - [ ] New feature
  - [ ] BC breaks
  - [ ] Deprecations
  - [ ] Changelog update (if required)

License: AGPLv3

- use `LOCK TABLE swp_article_statistics IN EXCLUSIVE MODE;` to eliminate database deadlocks for concurrent processes
- increase impressions and pageviews count using DQL
- added caching

<img width="853" alt="Zrzut ekranu 2019-06-07 13 15 50" src="https://user-images.githubusercontent.com/562536/59100472-6ce1a300-8926-11e9-9795-063828b2ba32.png">

