### PR TITLE
add latest items to content list serialized data in api

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Model/ContentList.php
+++ b/src/SWP/Bundle/CoreBundle/Model/ContentList.php
@@ -25,4 +25,19 @@ class ContentList extends BaseContentList implements ContentListInterface, Conte
     use TenantAwareTrait;
     use ContentListItemsCountTrait;
     use TimestampableCancelTrait;
+
+    /**
+     * NOT MAPPED property used for api purposes.
+     */
+    private $items;
+
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    public function setItems(array $items): void
+    {
+        $this->items = $items;
+    }
 }

--- a/src/SWP/Bundle/CoreBundle/Model/ContentListInterface.php
+++ b/src/SWP/Bundle/CoreBundle/Model/ContentListInterface.php
@@ -22,4 +22,7 @@ use SWP\Component\ContentList\Model\ContentListInterface as BaseContentListInter
 
 interface ContentListInterface extends BaseContentListInterface, TenantAwareInterface, TimestampableCancelInterface
 {
+    public function getItems(): array;
+
+    public function setItems(array $items): void;
 }

--- a/src/SWP/Bundle/CoreBundle/Resources/config/serializer/Model.ContentList.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/serializer/Model.ContentList.yml
@@ -5,6 +5,10 @@ SWP\Bundle\CoreBundle\Model\ContentList:
             expose: true
             groups: [api]
             type: SWP\Bundle\CoreBundle\Model\ContentListItemsCountInterface
+        items:
+            serialized_name: latest_items
+            expose: true
+            groups: [api]
     relations:
         -   rel: self
             href:

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -383,6 +383,8 @@ services:
             - { name: jms_serializer.event_subscriber }
 
     SWP\Bundle\CoreBundle\Serializer\ContentListSerializationSubscriber:
+        arguments:
+            - '@swp.repository.content_list_item'
         tags:
             - { name: jms_serializer.event_subscriber }
 

--- a/src/SWP/Bundle/CoreBundle/Tests/Controller/ContentListControllerTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Controller/ContentListControllerTest.php
@@ -260,6 +260,22 @@ class ContentListControllerTest extends WebTestCase
         self::assertEquals(1, $content['total']);
     }
 
+    public function testEmbedingFirstCOntentListItemsInCOntentList()
+    {
+        $this->loadFixtureFiles([
+            '@SWPFixturesBundle/Resources/fixtures/ORM/test/content_list.yml',
+            '@SWPFixturesBundle/Resources/fixtures/ORM/test/list_content.yml',
+            '@SWPFixturesBundle/Resources/fixtures/ORM/test/content_list_item.yml',
+        ], true);
+
+        $this->client->request('GET', $this->router->generate('swp_api_content_list_lists', ['id' => 1]));
+
+        self::assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+        self::assertCount(4, $content['_embedded']['_items'][0]['latest_items']);
+        self::assertEquals('article1', $content['_embedded']['_items'][0]['latest_items'][0]['content']['title']);
+    }
+
     public function testContentListItemsByAuthorFiltersApi()
     {
         $this->loadFixtureFiles([


### PR DESCRIPTION
Fixed tickets : SWP-1710
License: AGPLv3

In content list data we have now `latest_items` with first 5 items ordered by createdAt (`desc`). 