### PR TITLE
set jwt token in cookie on oauth success login

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Resources/config/controllers.yaml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/controllers.yaml
@@ -17,6 +17,7 @@ services:
   SWP\Bundle\CoreBundle\Controller\PackageSeoMediaUploadController: ~
   SWP\Bundle\CoreBundle\Controller\RedirectingController: ~
   SWP\Bundle\CoreBundle\Controller\SettingsController: ~
+  SWP\Bundle\CoreBundle\Controller\ExternalOauthController: ~
 
   takeit_amp_html.amp_controller:
     class: SWP\Bundle\CoreBundle\Controller\AmpController

--- a/src/SWP/Bundle/CoreBundle/Security/Authenticator/ExternalOauthAuthenticator.php
+++ b/src/SWP/Bundle/CoreBundle/Security/Authenticator/ExternalOauthAuthenticator.php
@@ -97,6 +97,7 @@ class ExternalOauthAuthenticator extends SocialAuthenticator
         $user->setPassword(uniqid('', true));
         $user->setEnabled(true);
         $user->setSuperAdmin(false);
+        $user->addRole('ROLE_USER');
 
         $this->um->updateUser($user);
 


### PR DESCRIPTION
License: AGPLv3

set jwt token in cookie on oauth success login to be able to get user profile/settings data from API.