### PR TITLE
log this same (and more) data to filesystem and graylog

### DIFF
--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -4,6 +4,8 @@ monolog:
         - swp_asset_download
         - swp_content_push
         - swp_image_conversion
+        - swp_rule
+        - swp_validators
     handlers:
         main:
             type:   stream

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -20,23 +20,15 @@ monolog:
         - swp_asset_download
         - swp_content_push
         - swp_image_conversion
+        - swp_rule
+        - swp_validators
     handlers:
-        main:
-            type:         fingers_crossed
-            action_level: error
-            handler:      nested
-            excluded_http_codes: [404]
-        nested:
-            type:  service
-            id:    monolog.gelf_handler
-            level: error
-            channels: ["!swp_send_webhook", "!swp_content_push", "!swp_image_conversion", "!swp_asset_download", "!swp_rule", "!swp_validators"]
         console:
             type:  console
-        gelf:
-            level: debug
-            type: service
-            id: monolog.gelf_handler
+        custom_channels:
+            type: fingers_crossed
+            action_level: debug
+            handler: grouped
             channels:
                 - swp_send_webhook
                 - swp_content_push
@@ -44,3 +36,20 @@ monolog:
                 - swp_asset_download
                 - swp_rule
                 - swp_validators
+        app:
+            type: fingers_crossed
+            action_level: error
+            handler: grouped
+            channels:
+                - app
+            excluded_http_codes: [404]
+        grouped:
+            type: whatfailuregroup
+            members: [streamed, gelf]
+        streamed:
+            type:  rotating_file
+            max_files: 7
+        gelf:
+            type: service
+            id: monolog.gelf_handler
+            include_stacktraces: true


### PR DESCRIPTION
Fixes:

Issue with production failing when correct graylog instance data are not set

## Proposed Changes

  - log this same data to graylog and filesystem 
  - log app channel data only when error level message i raised

License: AGPLv3
