### PR TITLE
set generated classes target dir to var/cache in PackageHydrator

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Hydrator/PackageHydrator.php
+++ b/src/SWP/Bundle/CoreBundle/Hydrator/PackageHydrator.php
@@ -23,9 +23,17 @@ use SWP\Bundle\CoreBundle\Model\PackageInterface;
 
 final class PackageHydrator implements PackageHydratorInterface
 {
+    private $generatedClassesTargetDir;
+
+    public function __construct(string $generatedClassesTargetDir)
+    {
+        $this->generatedClassesTargetDir = $generatedClassesTargetDir;
+    }
+
     public function hydrate(PackageInterface $newPackage, PackageInterface $existingPackage): PackageInterface
     {
         $config = new Configuration(Package::class);
+        $config->setGeneratedClassesTargetDir($this->generatedClassesTargetDir);
         $hydratorClass = $config->createFactory()->getHydratorClass();
         $hydrator = new $hydratorClass();
 

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -764,7 +764,9 @@ services:
 
     SWP\Bundle\CoreBundle\Factory\ApiKeyFactory: '@swp.factory.api_key'
 
-    SWP\Bundle\CoreBundle\Hydrator\PackageHydrator: ~
+    SWP\Bundle\CoreBundle\Hydrator\PackageHydrator:
+        arguments:
+            - '%kernel.cache_dir%'
 
     SWP\Bundle\CoreBundle\Hydrator\PackageHydratorInterface:
         alias: SWP\Bundle\CoreBundle\Hydrator\PackageHydrator


### PR DESCRIPTION
Changing default dir `/tmp` to `var/cache` in PackageHydrator.

License: AGPLv3
