### PR TITLE
expose route parent for templators

### DIFF
--- a/app/Resources/meta/route.yml
+++ b/app/Resources/meta/route.yml
@@ -23,4 +23,7 @@ properties:
     paywallSecured:
         description: "Is secured by the paywall?"
         type: bool
+    parent:
+        description: "Parent route meta"
+        type: meta
 to_string: path

--- a/src/SWP/Bundle/CoreBundle/Tests/Loader/ArticleLoaderTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Loader/ArticleLoaderTest.php
@@ -40,6 +40,14 @@ class ArticleLoaderTest extends WebTestCase
         self::assertContains('my custom field', $result);
     }
 
+    public function testRenderingRouteParent()
+    {
+        $template = '{% gimmelist article from articles with {"route": ["/sports"]} %} {{ article.route.parent.name }}  {% endgimmelist %}';
+        $result = $this->getRendered($template);
+
+        self::assertContains('news', $result);
+    }
+
     public function testFilteringByKeyword()
     {
         $template = '{% gimmelist article from articles with {keywords: ["car"]} %} {% for keyword in article.keywords %} {{ keyword }} {% endfor %} {% endgimmelist %}';

--- a/src/SWP/Bundle/CoreBundle/Tests/Loader/ArticleLoaderTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Loader/ArticleLoaderTest.php
@@ -42,9 +42,8 @@ class ArticleLoaderTest extends WebTestCase
 
     public function testRenderingRouteParent()
     {
-        $template = '{% gimmelist article from articles with {"route": ["/sports"]} %} {{ article.route.parent.name }}  {% endgimmelist %}';
+        $template = '{% gimmelist article from articles with {"route": ["/news/sports"]} %} {{ article.route.parent.name }}  {% endgimmelist %}';
         $result = $this->getRendered($template);
-
         self::assertContains('news', $result);
     }
 


### PR DESCRIPTION
Fixes SWP-1788

## Proposed Changes

  - expose `article.route.parent` (and `route.parent`)

License: AGPLv3
