### PR TITLE
Add lazy load attribute to embedded images

### DIFF
--- a/features/content_push/check_article_body_via_webhook.feature
+++ b/features/content_push/check_article_body_via_webhook.feature
@@ -133,7 +133,7 @@ Feature: Making sure that the "body" HTML tag is not added to article's body
     {
        "id":6,
        "title":"test image in body",
-       "body":"<p>test image in body<\/p><!-- EMBED START Image {id: \"editor_0\"} --><figure><img src=\"\/uploads\/swp\/123456\/media\/20161206161256_383592fef7acb9fc4731a24a691285b7bc51477264a5e343d95c74ccf1d85a93a.jpeg\" data-media-id=\"editor_0\" data-image-id=\"20161206161256_383592fef7acb9fc4731a24a691285b7bc51477264a5e343d95c74ccf1d85a93a\" data-rendition-name=\"original\" width=\"2048\" height=\"1365\" alt=\"Review Bombing\"><figcaption>Review Bombing<span><\/span><\/figcaption><\/figure><!-- EMBED END Image {id: \"editor_0\"} --><p>new line<\/p>",
+       "body":"<p>test image in body<\/p><!-- EMBED START Image {id: \"editor_0\"} --><figure><img src=\"\/uploads\/swp\/123456\/media\/20161206161256_383592fef7acb9fc4731a24a691285b7bc51477264a5e343d95c74ccf1d85a93a.jpeg\" data-media-id=\"editor_0\" data-image-id=\"20161206161256_383592fef7acb9fc4731a24a691285b7bc51477264a5e343d95c74ccf1d85a93a\" data-rendition-name=\"original\" width=\"2048\" height=\"1365\" loading=\"lazy\" alt=\"Review Bombing\"><figcaption>Review Bombing<span><\/span><\/figcaption><\/figure><!-- EMBED END Image {id: \"editor_0\"} --><p>new line<\/p>",
        "slug":"test-image-in-body",
        "status":"new",
        "route":{

--- a/src/SWP/Bundle/ContentBundle/Processor/EmbeddedImageProcessor.php
+++ b/src/SWP/Bundle/ContentBundle/Processor/EmbeddedImageProcessor.php
@@ -131,6 +131,7 @@ class EmbeddedImageProcessor implements EmbeddedImageProcessorInterface
         $imageElement->setAttribute('data-rendition-name', $this->getDefaultImageRendition());
         $imageElement->setAttribute('width', (string) $rendition->getWidth());
         $imageElement->setAttribute('height', (string) $rendition->getHeight());
+        $imageElement->setAttribute('loading', 'lazy');
 
         if (null !== $altAttribute && '' !== $altAttribute->nodeValue) {
             $imageElement->setAttribute('alt', $altAttribute->nodeValue);

--- a/src/SWP/Bundle/ContentBundle/Tests/Functional/EventListener/ProcessArticleMediaListenerTest.php
+++ b/src/SWP/Bundle/ContentBundle/Tests/Functional/EventListener/ProcessArticleMediaListenerTest.php
@@ -100,11 +100,11 @@ class ProcessArticleMediaListenerTest extends WebTestCase
         $this->getContainer()->get('event_dispatcher')->dispatch(ArticleEvents::PRE_CREATE, new ArticleEvent($article, $item));
 
         $embed1 = <<<'EOT'
-<!-- EMBED START Image {id: "embedded11331114891"} --> <figure><img src="/uploads/swp/media/58512be6c3a5be49fdca1178.jpeg" data-media-id="embedded11331114891" data-image-id="58512be6c3a5be49fdca1178" data-rendition-name="original" width="1200" height="797" alt="Stockholm, Sweden | Photo by Peter Adermark (CC BY-NC-ND 2.0)"><figcaption>Stockholm, Sweden | Photo by Peter Adermark (CC BY-NC-ND 2.0)<span>Ljuba Ranković</span></figcaption></figure> <!-- EMBED END Image {id: "embedded11331114891"} -->
+<!-- EMBED START Image {id: "embedded11331114891"} --> <figure><img src="/uploads/swp/media/58512be6c3a5be49fdca1178.jpeg" data-media-id="embedded11331114891" data-image-id="58512be6c3a5be49fdca1178" data-rendition-name="original" width="1200" height="797" loading="lazy" alt="Stockholm, Sweden | Photo by Peter Adermark (CC BY-NC-ND 2.0)"><figcaption>Stockholm, Sweden | Photo by Peter Adermark (CC BY-NC-ND 2.0)<span>Ljuba Ranković</span></figcaption></figure> <!-- EMBED END Image {id: "embedded11331114891"} -->
 EOT;
 
         $embed2 = <<<'EOT'
-<!-- EMBED START Image {id: "embedded5366428123"} --> <figure><img src="/uploads/swp/media/58512be4c3a5be49fdca1168.jpeg" data-media-id="embedded5366428123" data-image-id="58512be4c3a5be49fdca1168" data-rendition-name="original" width="1200" height="900" alt="Snapshot of the IPTC summer meeting | Photo by Jill Laurinaitis"><figcaption>Snapshot of the IPTC summer meeting | Photo by Jill Laurinaitis<span>Ljuba Ranković</span></figcaption></figure> <!-- EMBED END Image {id: "embedded5366428123"} -->
+<!-- EMBED START Image {id: "embedded5366428123"} --> <figure><img src="/uploads/swp/media/58512be4c3a5be49fdca1168.jpeg" data-media-id="embedded5366428123" data-image-id="58512be4c3a5be49fdca1168" data-rendition-name="original" width="1200" height="900" loading="lazy" alt="Snapshot of the IPTC summer meeting | Photo by Jill Laurinaitis"><figcaption>Snapshot of the IPTC summer meeting | Photo by Jill Laurinaitis<span>Ljuba Ranković</span></figcaption></figure> <!-- EMBED END Image {id: "embedded5366428123"} -->
 EOT;
         self::assertContains($embed1, $article->getBody());
         self::assertContains($embed2, $article->getBody());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | AGPLv3

# What does this PR do?

It adds the attribute "loading" with the value "lazy" on all embedded images.

# Why was this PR needed?

To ensure the speediest page load possible we can use the new "loading" attribute to lazy load images on the page: https://web.dev/native-lazy-loading/

# How can this PR be tested?

Publish an article with an embedded image and verify that it has the attribute "loading" with the value "lazy".

The "loading" attribute is currently only supported in Chrome. All other browsers will ignore it but are currently working on implementing support.

# References

- [Firefox support bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1542784)
- [WebKit support bug](https://bugs.webkit.org/show_bug.cgi?id=196698)
- [Description of the feature](https://web.dev/native-lazy-loading/)







