### PR TITLE
[fix] safely save loader parameters

### DIFF
--- a/src/SWP/Bundle/TemplatesSystemBundle/Loader/TraceableChainLoader.php
+++ b/src/SWP/Bundle/TemplatesSystemBundle/Loader/TraceableChainLoader.php
@@ -56,8 +56,8 @@ class TraceableChainLoader extends ChainLoader
 
                 $this->data['calledLoaders'][$loaderClass]['calls'][] = [
                     'type' => $type,
-                    'parameters' => $parameters,
-                    'withoutParameters' => $withoutParameters,
+                    'parameters' => json_encode($parameters, JSON_THROW_ON_ERROR, 512),
+                    'withoutParameters' => json_encode($withoutParameters, JSON_THROW_ON_ERROR, 512),
                     'responseType' => $responseType,
                     'duration' => $event->getDuration(),
                     'found' => false !== $meta,


### PR DESCRIPTION
Fixes problem with profile serialization with complex parameters passed to loaders used on page

License: AGPLv3
