### PR TITLE
Improve twig cache key generation

### DIFF
--- a/src/SWP/Bundle/ContentBundle/Resolver/AssetLocationResolver.php
+++ b/src/SWP/Bundle/ContentBundle/Resolver/AssetLocationResolver.php
@@ -58,7 +58,7 @@ class AssetLocationResolver implements AssetLocationResolverInterface
 
     private function getAwsUrl(FileInterface $file): string
     {
-        return  $this->awsClient->getObjectUrl($this->awsBucket, $this->awsPrefix.DIRECTORY_SEPARATOR.$this->getMediaBasePath().DIRECTORY_SEPARATOR.$file->getAssetId().'.'.$file->getFileExtension());
+        return  $this->awsClient->getObjectUrl($this->awsBucket, ($this->awsPrefix ?? $this->awsPrefix.DIRECTORY_SEPARATOR).$this->getMediaBasePath().DIRECTORY_SEPARATOR.$file->getAssetId().'.'.$file->getFileExtension());
     }
 
     private function getLocalUrl(FileInterface $file): string

--- a/src/SWP/Bundle/CoreBundle/Twig/Cache/KeyGenerator/TenantAwareMetaKeyGenerator.php
+++ b/src/SWP/Bundle/CoreBundle/Twig/Cache/KeyGenerator/TenantAwareMetaKeyGenerator.php
@@ -28,6 +28,6 @@ class TenantAwareMetaKeyGenerator extends MetaKeyGenerator
 
     public function generateKey($meta): string
     {
-        return $this->tenantContext->getTenant()->getCode().'_'.md5(parent::generateKey($meta));
+        return $this->tenantContext->getTenant()->getCode().'_'.parent::generateKey($meta);
     }
 }

--- a/src/SWP/Bundle/CoreBundle/Twig/Cache/Strategy/LifetimeCacheStrategy.php
+++ b/src/SWP/Bundle/CoreBundle/Twig/Cache/Strategy/LifetimeCacheStrategy.php
@@ -36,7 +36,7 @@ class LifetimeCacheStrategy extends BaseLifetimeCacheStrategy
      */
     public function generateKey($annotation, $value)
     {
-        $annotation = $this->tenantContext->getTenant()->getCode().'__'.md5($annotation);
+        $annotation = $this->tenantContext->getTenant()->getCode().'__'.sha1($annotation);
 
         return parent::generateKey($annotation, $value);
     }

--- a/src/SWP/Bundle/CoreBundle/Twig/Cache/Strategy/TagAwareIndexedChainingCacheStrategy.php
+++ b/src/SWP/Bundle/CoreBundle/Twig/Cache/Strategy/TagAwareIndexedChainingCacheStrategy.php
@@ -37,7 +37,7 @@ class TagAwareIndexedChainingCacheStrategy extends BaseIndexedChainingCacheStrat
 
     public function fetchBlock($key)
     {
-        $fetchedBlock = parent::fetchBlock($this->cleanUpKey($key));
+        $fetchedBlock = parent::fetchBlock($key);
         if (false === $fetchedBlock) {
             $this->tagsCollector->startNewCacheBlock($this->getKeyString($key));
         } else {
@@ -52,16 +52,7 @@ class TagAwareIndexedChainingCacheStrategy extends BaseIndexedChainingCacheStrat
         $this->tagsCollector->flushCurrentCacheBlockTags();
         $this->responseTagger->addTags($this->tagsCollector->getCurrentCacheBlockTags());
 
-        return parent::saveBlock($this->cleanUpKey($key), $block);
-    }
-
-    private function cleanUpKey(array $key): array
-    {
-        if (isset($key['key']) && is_string($key['key'])) {
-            $key['key'] = md5($key['key']);
-        }
-
-        return $key;
+        return parent::saveBlock($key, $block);
     }
 
     private function getKeyString(array $key): string

--- a/src/SWP/Bundle/FixturesBundle/DataFixtures/ORM/LoadArticlesData.php
+++ b/src/SWP/Bundle/FixturesBundle/DataFixtures/ORM/LoadArticlesData.php
@@ -23,14 +23,15 @@ use SWP\Bundle\AnalyticsBundle\Model\ArticleStatisticsInterface;
 use SWP\Bundle\ContentBundle\Model\ArticleAuthor;
 use SWP\Bundle\ContentBundle\Model\ArticleInterface;
 use SWP\Bundle\ContentBundle\Model\AuthorMedia;
-use SWP\Bundle\ContentBundle\Model\RelatedArticle;
-use SWP\Bundle\CoreBundle\Model\Image;
 use SWP\Bundle\ContentBundle\Model\ImageRendition;
+use SWP\Bundle\ContentBundle\Model\RelatedArticle;
 use SWP\Bundle\ContentBundle\Model\RouteInterface;
+use SWP\Bundle\CoreBundle\Model\Image;
 use SWP\Bundle\CoreBundle\Model\PackageInterface;
 use SWP\Bundle\FixturesBundle\AbstractFixture;
 use SWP\Bundle\FixturesBundle\Faker\Provider\ArticleDataProvider;
 use SWP\Component\Bridge\Model\ExternalDataInterface;
+use SWP\Component\Bridge\Model\Rendition;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class LoadArticlesData extends AbstractFixture implements OrderedFixtureInterface
@@ -309,7 +310,7 @@ class LoadArticlesData extends AbstractFixture implements OrderedFixtureInterfac
                     $articleMedia->setMimetype('image/jpeg');
                     $manager->persist($articleMedia);
 
-                    $randNumber = rand(1, 9);
+                    $randNumber = random_int(1, 9);
                     /* @var $rendition Rendition */
                     foreach ($renditions as $key => $rendition) {
                         if ('original' === $key) {
@@ -321,7 +322,7 @@ class LoadArticlesData extends AbstractFixture implements OrderedFixtureInterfac
                             $fakeImage = '/tmp/'.$randNumber.'org'.$key.'.jpg';
                         }
 
-                        $mediaId = uniqid();
+                        $mediaId = uniqid('', true);
                         $uploadedFile = new UploadedFile(
                             $fakeImage,
                             $mediaId,
@@ -542,9 +543,9 @@ class LoadArticlesData extends AbstractFixture implements OrderedFixtureInterfac
 
             $article->addRelatedArticle($related1);
             $article->addRelatedArticle($related2);
-
-            $manager->flush();
         }
+
+        $manager->flush();
     }
 
     private function createPackage(array $articleData): PackageInterface

--- a/src/SWP/Bundle/FixturesBundle/Resources/fixtures/ORM/dev/article.yml
+++ b/src/SWP/Bundle/FixturesBundle/Resources/fixtures/ORM/dev/article.yml
@@ -1,5 +1,5 @@
 SWP\Bundle\CoreBundle\Model\Article:
-    article{1..20}:
+    article{1..10}:
         title: "<catchPhrase()> <numberBetween(1, 200)>"
         body: '<paragraph(10)> <articleEmbed()> <paragraph(10)>'
         route: "<getRouteByName('politics')>"
@@ -12,7 +12,7 @@ SWP\Bundle\CoreBundle\Model\Article:
         keywords: "<articleKeywords()>"
         code: "<uuid()>"
         package: "@package*"
-    article{21..40}:
+    article{11..20}:
         title: "<catchPhrase()> <numberBetween(1, 200)>"
         body: '<paragraph(10)> <articleEmbed()> <paragraph(10)>'
         route: "<getRouteByName('business')>"
@@ -25,7 +25,7 @@ SWP\Bundle\CoreBundle\Model\Article:
         keywords: "<articleKeywords()>"
         code: "<uuid()>"
         package: "@package*"
-    article{41..60}:
+    article{21..30}:
         title: "<catchPhrase()> <numberBetween(1, 200)>"
         body: '<paragraph(10)> <articleEmbed()> <paragraph(10)>'
         route: "<getRouteByName('scitech')>"
@@ -38,7 +38,7 @@ SWP\Bundle\CoreBundle\Model\Article:
         keywords: "<articleKeywords()>"
         code: "<uuid()>"
         package: "@package*"
-    article{61..80}:
+    article{31..40}:
         title: "<catchPhrase()> <numberBetween(1, 200)>"
         body: '<paragraph(10)> <articleEmbed()> <paragraph(10)>'
         route: "<getRouteByName('health')>"
@@ -51,7 +51,7 @@ SWP\Bundle\CoreBundle\Model\Article:
         keywords: "<articleKeywords()>"
         code: "<uuid()>"
         package: "@package*"
-    article{81..100}:
+    article{41..50}:
         title: "<catchPhrase()> <numberBetween(1, 200)>"
         body: '<paragraph(10)> <articleEmbed()> <paragraph(10)>'
         route: "<getRouteByName('entertainment')>"
@@ -64,7 +64,7 @@ SWP\Bundle\CoreBundle\Model\Article:
         keywords: "<articleKeywords()>"
         code: "<uuid()>"
         package: "@package*"
-    article{101..120}:
+    article{51..65}:
         title: "<catchPhrase()> <numberBetween(1, 200)>"
         body: '<paragraph(10)> <articleEmbed()> <paragraph(10)>'
         route: "<getRouteByName('sports')>"

--- a/symfony.lock
+++ b/symfony.lock
@@ -931,6 +931,12 @@
             "src/Kernel.php"
         ]
     },
+    "symfony/http-client": {
+        "version": "v5.0.1"
+    },
+    "symfony/http-client-contracts": {
+        "version": "v2.0.1"
+    },
     "symfony/http-foundation": {
         "version": "v4.2.7"
     },


### PR DESCRIPTION
## Proposed Changes

  - remove cache key md5 hashing, make sure that annotations are hashed in generational and lifetime strategies
  - don't use aws prefix if not set
  - limit number of articles in dev fixtures

License: AGPLv3
