### PR TITLE
add article to matching content list after correction

### DIFF
--- a/features/content_lists/add_article_to_automatic_list_after_update.feature
+++ b/features/content_lists/add_article_to_automatic_list_after_update.feature
@@ -1,0 +1,98 @@
+@disable-fixtures
+@content_lists
+Feature: Add article to automatic list after update (when criteria are matched)
+  In order to add article to automatic content lists
+  As a HTTP Client
+  I want to be able to push corrected content and see it in content lists
+
+  Scenario: Push new article and add it to automatic content lists
+    Given the following Tenants:
+      | organization | name | subdomain | domain_name | enabled | default | code   |
+      | Default      | test |           | localhost   | true    | true    | 123abc |
+
+    Given the following Content Lists:
+      | name                 | type      | filters                                                        |
+      | first content list   | automatic | {"metadata":{"subject":[{"name":"lawyer","code":"02002001"}]}} |
+
+
+    Given the following Users:
+      | username   | email                      | token      | plainPassword | role                | enabled |
+      | test.user  | test.user@sourcefabric.org | test_user: | testPassword  | ROLE_INTERNAL_API   | true    |
+
+    Given the following Routes:
+      |  name | type       | slug |
+      |  test | collection | test |
+
+    Given the following organization publishing rule:
+    """
+      {
+        "name":"Test rule",
+        "description":"Test rule description",
+        "priority":1,
+        "expression":"true == true",
+        "configuration":[
+          {
+            "key":"destinations",
+            "value":[
+              {
+                "tenant":"123abc"
+              }
+            ]
+          }
+        ]
+      }
+    """
+
+    Given default tenant with code "123abc"
+    Given the following tenant publishing rule:
+    """
+      {
+          "name":"Test tenant rule",
+          "description":"Test tenant rule description",
+          "priority":1,
+          "expression":"article.getPackage().getLanguage() == 'en'",
+          "configuration":[
+            {
+              "key":"route",
+              "value":1
+            },
+            {
+              "key":"published",
+              "value":true
+            }
+          ]
+       }
+    """
+
+    Given I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/api/v2/content/push" with body:
+    """
+    {
+        "language":"en","headline":"Test Package","version":"2","guid":"16e111d5","priority":6,"type":"text",
+        "authors":[{"name":"Tom Doe","role":"editor"}],
+        "byline":"Admin"
+    }
+    """
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v2/content/lists/1/items/"
+    And the JSON node "total" should be equal to "0"
+
+    Given I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/api/v2/content/push" with body:
+    """
+    {
+        "language":"en","headline":"Test Package","version":"2","guid":"16e111d5","priority":6,"type":"text",
+        "authors":[{"name":"Tom Doe","role":"editor"}],
+        "byline":"Admin",
+        "subject":[{"name":"lawyer","code":"02002001"}]
+    }
+    """
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v2/content/lists/1/items/"
+    And the JSON node "total" should be equal to "1"

--- a/src/SWP/Bundle/CoreBundle/Controller/ContentListItemController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/ContentListItemController.php
@@ -19,10 +19,6 @@ use DateTimeZone;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Operation;
 use Swagger\Annotations as SWG;
-use SWP\Component\Common\Response\ResourcesListResponseInterface;
-use SWP\Component\Common\Response\SingleResourceResponseInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Routing\Annotation\Route;
 use SWP\Bundle\ContentBundle\ArticleEvents;
 use SWP\Bundle\ContentBundle\Event\ArticleEvent;
 use SWP\Bundle\ContentListBundle\Form\Type\ContentListItemsType;
@@ -32,11 +28,15 @@ use SWP\Bundle\CoreBundle\Model\ContentListItemInterface;
 use SWP\Component\Common\Criteria\Criteria;
 use SWP\Component\Common\Pagination\PaginationData;
 use SWP\Component\Common\Response\ResourcesListResponse;
+use SWP\Component\Common\Response\ResourcesListResponseInterface;
 use SWP\Component\Common\Response\ResponseContext;
 use SWP\Component\Common\Response\SingleResourceResponse;
+use SWP\Component\Common\Response\SingleResourceResponseInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
 
 class ContentListItemController extends AbstractController
 {

--- a/src/SWP/Bundle/CoreBundle/EventListener/AddArticleToListListener.php
+++ b/src/SWP/Bundle/CoreBundle/EventListener/AddArticleToListListener.php
@@ -97,7 +97,7 @@ class AddArticleToListListener
                 continue;
             }
 
-            if (null !== $item) {
+            if (null !== $item && count($filters) > 0 && !$this->articleCriteriaMatcher->match($article, new Criteria($filters))) {
                 $this->contentListItemRepository->remove($item);
                 $contentList->setUpdatedAt(new \DateTime());
             }

--- a/src/SWP/Bundle/CoreBundle/EventListener/AddArticleToListListener.php
+++ b/src/SWP/Bundle/CoreBundle/EventListener/AddArticleToListListener.php
@@ -84,18 +84,18 @@ class AddArticleToListListener
         ]);
 
         foreach ($contentLists as $contentList) {
-            $filters = $contentList->getFilters();
-            if ($this->articleCriteriaMatcher->match($article, new Criteria($filters))) {
-                $this->createAndAddItem($article, $contentList);
-
-                continue;
-            }
-
             $item = $this->contentListItemRepository->findItemByArticleAndList(
                 $article,
                 $contentList,
                 ContentListInterface::TYPE_AUTOMATIC
             );
+
+            $filters = $contentList->getFilters();
+            if (null === $item && $this->articleCriteriaMatcher->match($article, new Criteria($filters))) {
+                $this->createAndAddItem($article, $contentList);
+
+                continue;
+            }
 
             if (null !== $item) {
                 $this->contentListItemRepository->remove($item);

--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -181,6 +181,7 @@ services:
             - '@swp.repository.content_list_item'
         tags:
             - { name: kernel.event_listener, event: swp.article.publish, method: addArticleToList }
+            - { name: kernel.event_listener, event: swp.article.post_update, method: addArticleToList }
             - { name: kernel.event_listener, event: swp.article.publish, method: addArticleToBucket }
 
     SWP\Bundle\CoreBundle\EventSubscriber\HandleArticleChangeSubscriber:

--- a/src/SWP/Bundle/CoreBundle/spec/EventListener/AddArticleToListListenerSpec.php
+++ b/src/SWP/Bundle/CoreBundle/spec/EventListener/AddArticleToListListenerSpec.php
@@ -14,13 +14,14 @@
 
 namespace spec\SWP\Bundle\CoreBundle\EventListener;
 
+use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use SWP\Bundle\ContentBundle\Event\ArticleEvent;
 use SWP\Bundle\ContentListBundle\Event\ContentListEvent;
 use SWP\Bundle\CoreBundle\EventListener\AddArticleToListListener;
-use PhpSpec\ObjectBehavior;
 use SWP\Bundle\CoreBundle\Matcher\ArticleCriteriaMatcherInterface;
 use SWP\Bundle\CoreBundle\Model\Article;
+use SWP\Bundle\CoreBundle\Model\ArticleInterface;
 use SWP\Bundle\CoreBundle\Model\ContentListInterface;
 use SWP\Bundle\CoreBundle\Model\ContentListItemInterface;
 use SWP\Bundle\CoreBundle\Repository\ContentListItemRepositoryInterface;
@@ -69,6 +70,11 @@ final class AddArticleToListListenerSpec extends ObjectBehavior
         $list->getFilters()->willReturn(['metadata' => ['locale' => 'en']]);
         $listRepository->findByTypes(['automatic'])->willReturn([$list]);
         $listItemRepository->persist(Argument::any())->shouldBeCalled();
+        $listItemRepository->findItemByArticleAndList(
+            Argument::type(ArticleInterface::class),
+            Argument::type(ContentListInterface::class),
+            'automatic'
+        )->willReturn(null);
 
         $articleCriteriaMatcher->match($article, new Criteria(['metadata' => ['locale' => 'en']]))->willReturn(true);
 


### PR DESCRIPTION
Use case: On first publish action editor forgot to set correct keywords in article, he does that with correction and then article should be added to matching content list

Fixes # SWP-1840


License: AGPLv3
