### PR TITLE
exclude articles by routes

### DIFF
--- a/features/twig/loaders/exclude_articles_by_routes.feature
+++ b/features/twig/loaders/exclude_articles_by_routes.feature
@@ -1,0 +1,65 @@
+@disable-fixtures
+Feature: Exclude articles by routes
+  In order to show a curated list of articles
+  As a template implementor
+  I want to be able to exclude articles by route ids
+
+  Background:
+    Given the following Tenants:
+      | organization | name | subdomain | domain_name | enabled | default |
+      | Default      | test |           | localhost   | true    | true    |
+
+    Given the following Articles:
+      | title                | route    | status    |
+      | First Test Article   | Sports   | published |
+      | Second Test Article  | Sports   | published |
+      | Third Test Article   | Politics | published |
+      | Health Test Article  | Health   | published |
+
+  Scenario: Render all articles
+    Given I render a template with content:
+     """
+     {% gimmelist article from articles %}
+        {{ article.title }}-{{ article.id }}-{{ article.route.name }}
+     {% endgimmelist %}
+     """
+    Then rendered template should contain "First Test Article-1-Sports"
+    Then rendered template should contain "Second Test Article-2-Sports"
+    Then rendered template should contain "Third Test Article-3-Politics"
+    Then rendered template should contain "Health Test Article-4-Health"
+
+  Scenario: Exclude articles by Politics route
+    And I render a template with content:
+     """
+     {% gimmelist article from articles without { route: [2] } %}
+        {{ article.title }}-{{ article.id }}-{{ article.route.name }}
+     {% endgimmelist %}
+     """
+    Then rendered template should contain "First Test Article-1-Sports"
+    Then rendered template should contain "Second Test Article-2-Sports"
+    Then rendered template should not contain "Third Test Article-3-Politics"
+    Then rendered template should contain "Health Test Article-4-Health"
+
+  Scenario: Exclude articles by Sports route
+    And I render a template with content:
+     """
+     {% gimmelist article from articles without { route: [1] } %}
+        {{ article.title }}-{{ article.id }}-{{ article.route.name }}
+     {% endgimmelist %}
+     """
+    Then rendered template should not contain "First Test Article-1-Sports"
+    Then rendered template should not contain "Second Test Article-2-Sports"
+    Then rendered template should contain "Third Test Article-3-Politics"
+    Then rendered template should contain "Health Test Article-4-Health"
+
+  Scenario: Exclude articles by Health route
+    And I render a template with content:
+     """
+     {% gimmelist article from articles without { route: [3,4] } %}
+        {{ article.title }}-{{ article.id }}-{{ article.route.name }}
+     {% endgimmelist %}
+     """
+    Then rendered template should contain "First Test Article-1-Sports"
+    Then rendered template should contain "Second Test Article-2-Sports"
+    Then rendered template should not contain "Third Test Article-3-Politics"
+    Then rendered template should not contain "Health Test Article-4-Health"

--- a/features/twig/loaders/exclude_articles_by_routes.feature
+++ b/features/twig/loaders/exclude_articles_by_routes.feature
@@ -16,7 +16,7 @@ Feature: Exclude articles by routes
       | Third Test Article   | Politics | published |
       | Health Test Article  | Health   | published |
 
-  Scenario: Render all articles
+  Scenario: Exclude articles by routes
     Given I render a template with content:
      """
      {% gimmelist article from articles %}
@@ -28,10 +28,9 @@ Feature: Exclude articles by routes
     Then rendered template should contain "Third Test Article-3-Politics"
     Then rendered template should contain "Health Test Article-4-Health"
 
-  Scenario: Exclude articles by Politics route
     And I render a template with content:
      """
-     {% gimmelist article from articles without { route: [2] } %}
+     {% gimmelist article from articles without { route: [2] } ignoreContext ['route'] %}
         {{ article.title }}-{{ article.id }}-{{ article.route.name }}
      {% endgimmelist %}
      """
@@ -40,10 +39,9 @@ Feature: Exclude articles by routes
     Then rendered template should not contain "Third Test Article-3-Politics"
     Then rendered template should contain "Health Test Article-4-Health"
 
-  Scenario: Exclude articles by Sports route
     And I render a template with content:
      """
-     {% gimmelist article from articles without { route: [1] } %}
+     {% gimmelist article from articles without { route: [1] } ignoreContext ['route'] %}
         {{ article.title }}-{{ article.id }}-{{ article.route.name }}
      {% endgimmelist %}
      """
@@ -52,10 +50,9 @@ Feature: Exclude articles by routes
     Then rendered template should contain "Third Test Article-3-Politics"
     Then rendered template should contain "Health Test Article-4-Health"
 
-  Scenario: Exclude articles by Health route
     And I render a template with content:
      """
-     {% gimmelist article from articles without { route: [3,4] } %}
+     {% gimmelist article from articles without { route: [2,3] } ignoreContext ['route'] %}
         {{ article.title }}-{{ article.id }}-{{ article.route.name }}
      {% endgimmelist %}
      """

--- a/src/SWP/Bundle/ContentBundle/Doctrine/ORM/ArticleRepository.php
+++ b/src/SWP/Bundle/ContentBundle/Doctrine/ORM/ArticleRepository.php
@@ -298,5 +298,13 @@ class ArticleRepository extends EntityRepository implements ArticleRepositoryInt
                 ->setParameter('excludedArticles', $excludedArticles);
             $criteria->remove('exclude_article');
         }
+
+        if ($criteria->has('exclude_route') && !empty($criteria->get('exclude_route'))) {
+            $andX = $queryBuilder->expr()->andX();
+            $andX->add($queryBuilder->expr()->notIn('a.route', (array) $criteria->get('exclude_route')));
+            $queryBuilder->andWhere($andX);
+
+            $criteria->remove('exclude_route');
+        }
     }
 }

--- a/src/SWP/Bundle/ContentBundle/Loader/ArticleLoader.php
+++ b/src/SWP/Bundle/ContentBundle/Loader/ArticleLoader.php
@@ -107,6 +107,10 @@ class ArticleLoader extends PaginatedLoader implements LoaderInterface
                 $criteria->set('route', $route);
             }
 
+            if (isset($withoutParameters['route'])) {
+                $criteria->set('exclude_route', $withoutParameters['route']);
+            }
+
             foreach (['metadata', 'extra', 'keywords', 'source', 'author', 'article', 'publishedAfter', 'publishedBefore'] as $item) {
                 if (isset($parameters[$item])) {
                     $criteria->set($item, $parameters[$item]);


### PR DESCRIPTION
## Fixes 

SWP-1854

## Proposed Changes

This PR adds a new feature which allows excluding articles by route ids in twig templates.

Usage:

```twig
     {% gimmelist article from articles without { route: [2] } %}
        {{ article.title }}-{{ article.id }}-{{ article.route.name }}
     {% endgimmelist %}
```

License: AGPLv3
