### PR TITLE
search articles by exact author name

### DIFF
--- a/features/02_articles/searching_articles_by_authors.feature
+++ b/features/02_articles/searching_articles_by_authors.feature
@@ -4,7 +4,7 @@ Feature: Filtering/searching existing articles by authors
   As a HTTP Client
   I want to be able to check if filtering works properly
 
-  Scenario: Searching/filtering articles by authors
+  Scenario: Searching/filtering articles by exact authors names
     And I am authenticated as "test.user"
     And I add "Content-Type" header equal to "application/json"
     And I run "fos:elastica:populate --env=test" command
@@ -12,3 +12,21 @@ Feature: Filtering/searching existing articles by authors
     Then I send a "GET" request to "/api/v2/content/articles/?author[]=Tom"
     Then the response status code should be 200
     And the JSON node "total" should be equal to "1"
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v2/content/articles/?author[]=John Doe"
+    Then the response status code should be 200
+    And the JSON node "total" should be equal to "1"
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v2/content/articles/?author[]=John Doe Second"
+    Then the response status code should be 200
+    And the JSON node "total" should be equal to "1"
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v2/content/articles/?author[]=John"
+    Then the response status code should be 200
+    And the JSON node "total" should be equal to "0"

--- a/src/SWP/Bundle/ElasticSearchBundle/Repository/ArticleRepository.php
+++ b/src/SWP/Bundle/ElasticSearchBundle/Repository/ArticleRepository.php
@@ -64,7 +64,10 @@ class ArticleRepository extends Repository
 
         if (null !== $fields->get('authors') && !empty($fields->get('authors'))) {
             $bool = new BoolQuery();
-            $bool->addFilter(new Query\Terms('authors.name', $fields->get('authors')));
+            foreach ($fields->get('authors') as $author) {
+                $bool->addFilter(new Query\Match('authors.name', $author));
+            }
+
             $nested = new Nested();
             $nested->setPath('authors');
             $nested->setQuery($bool);

--- a/src/SWP/Bundle/ElasticSearchBundle/Resources/config/app/config.yml
+++ b/src/SWP/Bundle/ElasticSearchBundle/Resources/config/app/config.yml
@@ -17,7 +17,7 @@ fos_elastica:
                             filter: [lowercase]
                         swp_author_name_analyzer:
                             type: custom
-                            tokenizer: standard
+                            tokenizer: keyword
                         swp_sources_analyzer:
                             type: custom
                             tokenizer: keyword


### PR DESCRIPTION
## Fixes
Improved articles search by authors.

For example, there are two authors with names: `John Doe` and `John Doe Second`. 
When searching for `John` no results will be returned.
When searching for `John Doe Second` the articles by `John Doe Second` will only be returned.
When searching for `John Doe` the articles by `John Doe` will only be returned.

## Proposed Changes

  - Search articles by exact author-name


License: AGPLv3
