### PR TITLE
handle items with slugline property set to empty string

### DIFF
--- a/features/02_articles/validating_article_slugline.feature
+++ b/features/02_articles/validating_article_slugline.feature
@@ -239,3 +239,53 @@ Feature: Validating if article slugline is created out of the package headline
     Then I send a "GET" request to "/api/v2/content/articles/hu-zong-zhi-shou-die-zhong-zhi-san-lian-zhang-shang-gong-dong-li-bu-zu-cheng-jiao-liang-zai-xian-wei-suo"
     Then the response status code should be 200
     And the JSON node "slug" should be equal to "hu-zong-zhi-shou-die-zhong-zhi-san-lian-zhang-shang-gong-dong-li-bu-zu-cheng-jiao-liang-zai-xian-wei-suo"
+
+  Scenario: Validate package with slugline set to empty string
+    Given I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/api/v2/content/push" with body:
+    """
+    {
+      "language":"en",
+      "body_html":"<p>some html body</p>",
+      "versioncreated":"2016-09-23T13:57:28+0000",
+      "firstcreated":"2016-09-23T09:11:28+0000",
+      "description_text":"some abstract text",
+      "version":"2",
+      "byline":"ADmin",
+      "keywords":[
+        "test keyword"
+      ],
+      "guid":"urn:newsml:localhost:2016-09-23T13:56:39.404843:56465de4-0d5c-495a-8e36-3b396def3cf1",
+      "priority":6,
+      "urgency":3,
+      "type":"text",
+      "headline":"Abstract html test second",
+      "slugline": "",
+      "description_html":"<p><b><u>some abstract text</u></b></p>",
+      "located":"Sydney",
+      "pubstatus":"usable"
+    }
+    """
+    Then the response status code should be 201
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "POST" request to "/api/v2/packages/9/publish/" with body:
+     """
+      {
+          "destinations":[
+            {
+              "tenant":"123abc",
+              "route":6,
+              "is_published_fbia":false
+            }
+          ]
+      }
+     """
+    Then the response status code should be 201
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v2/content/articles/abstract-html-test-second"
+    Then the response status code should be 200
+    And the JSON node "slug" should be equal to "abstract-html-test-second"

--- a/features/content_lists/add_article_to_automatic_list_after_update.feature
+++ b/features/content_lists/add_article_to_automatic_list_after_update.feature
@@ -96,3 +96,20 @@ Feature: Add article to automatic list after update (when criteria are matched)
     And I add "Content-Type" header equal to "application/json"
     Then I send a "GET" request to "/api/v2/content/lists/1/items/"
     And the JSON node "total" should be equal to "1"
+
+    Given I am authenticated as "test.user"
+    When I add "Content-Type" header equal to "application/json"
+    And I send a "POST" request to "/api/v2/content/push" with body:
+    """
+    {
+        "language":"en","headline updated":"Test Package","version":"3","guid":"16e111d5","priority":6,"type":"text",
+        "authors":[{"name":"Tom Doe","role":"editor"}],
+        "byline":"Admin",
+        "subject":[{"name":"lawyer","code":"02002001"}]
+    }
+    """
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v2/content/lists/1/items/"
+    And the JSON node "total" should be equal to "1"

--- a/src/SWP/Bundle/BridgeBundle/EventListener/ValidationListener.php
+++ b/src/SWP/Bundle/BridgeBundle/EventListener/ValidationListener.php
@@ -27,9 +27,6 @@ final class ValidationListener
      */
     private $validator;
 
-    /**
-     * @param ValidatorInterface $validator
-     */
     public function __construct(ValidatorInterface $validator)
     {
         $this->validator = $validator;

--- a/src/SWP/Bundle/ContentBundle/Model/Article.php
+++ b/src/SWP/Bundle/ContentBundle/Model/Article.php
@@ -221,7 +221,7 @@ class Article implements ArticleInterface
     {
         $this->title = $title;
 
-        if (null !== $this->slug) {
+        if (null !== $this->slug && '' !== $this->slug) {
             $this->setSlug($this->slug);
 
             return;

--- a/src/SWP/Bundle/CoreBundle/Consumer/ContentPushConsumer.php
+++ b/src/SWP/Bundle/CoreBundle/Consumer/ContentPushConsumer.php
@@ -115,6 +115,7 @@ class ContentPushConsumer implements ConsumerInterface
 
             return ConsumerInterface::MSG_REJECT;
         } finally {
+            $this->reset();
             $lock->release();
         }
     }


### PR DESCRIPTION
## Proposed Changes

* use title when slugline is set to empty string
* reset entity manager when exception is cached in content push consumer

License: AGPLv3
