### PR TITLE
Support Token Authenticator only in the API

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Security/Authenticator/TokenAuthenticator.php
+++ b/src/SWP/Bundle/CoreBundle/Security/Authenticator/TokenAuthenticator.php
@@ -132,23 +132,6 @@ class TokenAuthenticator extends AbstractGuardAuthenticator
 
     public function supports(Request $request): bool
     {
-//        $token = $this->getToken($request);
-//        $isApi = $request->attributes->get('_fos_rest_zone');
-//
-//        if (false === $isApi && $request->query->has('auth_token')) {
-//            return true;
-//        }
-//
-//        if (false === $isApi && null !== $token && false === strpos($token, 'Bearer ') && !$request->query->has('auth_token')) {
-//            return false;
-//        }
-//
-//        if (false === $isApi) {
-//            return false;
-//        }
-//
-//        return true;
-
         $token = $this->getToken($request);
         $isApi = $request->attributes->get('_fos_rest_zone');
 

--- a/src/SWP/Bundle/CoreBundle/Security/Authenticator/TokenAuthenticator.php
+++ b/src/SWP/Bundle/CoreBundle/Security/Authenticator/TokenAuthenticator.php
@@ -139,11 +139,15 @@ class TokenAuthenticator extends AbstractGuardAuthenticator
             return true;
         }
 
+        if (false === $isApi && null !== $token && false === strpos($token, 'Bearer ') && !$request->query->has('auth_token')) {
+            return false;
+        }
+
         if (false === $isApi) {
             return false;
         }
 
-        return null !== $token && false === strpos($token, 'Bearer ');
+        return true;
     }
 
     private function getToken(Request $request): ?string

--- a/src/SWP/Bundle/CoreBundle/Security/Authenticator/TokenAuthenticator.php
+++ b/src/SWP/Bundle/CoreBundle/Security/Authenticator/TokenAuthenticator.php
@@ -132,9 +132,13 @@ class TokenAuthenticator extends AbstractGuardAuthenticator
 
     public function supports(Request $request): bool
     {
+        if (!$request->attributes->get('_fos_rest_zone')) {
+            return false;
+        }
+
         $token = $this->getToken($request);
 
-        return $token && false === strpos($token, 'Bearer ');
+        return null !== $token && false === strpos($token, 'Bearer ');
     }
 
     private function getToken(Request $request): ?string

--- a/src/SWP/Bundle/CoreBundle/Security/Authenticator/TokenAuthenticator.php
+++ b/src/SWP/Bundle/CoreBundle/Security/Authenticator/TokenAuthenticator.php
@@ -132,11 +132,16 @@ class TokenAuthenticator extends AbstractGuardAuthenticator
 
     public function supports(Request $request): bool
     {
-        if (!$request->attributes->get('_fos_rest_zone')) {
-            return false;
+        $token = $this->getToken($request);
+        $isApi = $request->attributes->get('_fos_rest_zone');
+
+        if (false === $isApi && $request->query->has('auth_token')) {
+            return true;
         }
 
-        $token = $this->getToken($request);
+        if (false === $isApi) {
+            return false;
+        }
 
         return null !== $token && false === strpos($token, 'Bearer ');
     }

--- a/src/SWP/Bundle/CoreBundle/Security/Authenticator/TokenAuthenticator.php
+++ b/src/SWP/Bundle/CoreBundle/Security/Authenticator/TokenAuthenticator.php
@@ -132,6 +132,23 @@ class TokenAuthenticator extends AbstractGuardAuthenticator
 
     public function supports(Request $request): bool
     {
+//        $token = $this->getToken($request);
+//        $isApi = $request->attributes->get('_fos_rest_zone');
+//
+//        if (false === $isApi && $request->query->has('auth_token')) {
+//            return true;
+//        }
+//
+//        if (false === $isApi && null !== $token && false === strpos($token, 'Bearer ') && !$request->query->has('auth_token')) {
+//            return false;
+//        }
+//
+//        if (false === $isApi) {
+//            return false;
+//        }
+//
+//        return true;
+
         $token = $this->getToken($request);
         $isApi = $request->attributes->get('_fos_rest_zone');
 
@@ -139,15 +156,11 @@ class TokenAuthenticator extends AbstractGuardAuthenticator
             return true;
         }
 
-        if (false === $isApi && null !== $token && false === strpos($token, 'Bearer ') && !$request->query->has('auth_token')) {
-            return false;
-        }
-
         if (false === $isApi) {
             return false;
         }
 
-        return true;
+        return null !== $token && false === strpos($token, 'Bearer ');
     }
 
     private function getToken(Request $request): ?string

--- a/src/SWP/Bundle/CoreBundle/Tests/ContentPushTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/ContentPushTest.php
@@ -606,6 +606,9 @@ final class ContentPushTest extends WebTestCase
 
         // test package preview
         $client->request('GET', $this->router->generate('swp_package_preview', ['routeId' => 3, 'id' => 1]));
+        self::assertEquals(401, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', $this->router->generate('swp_package_preview', ['routeId' => 3, 'id' => 1, 'auth_token' => base64_encode('test_token:')]));
         self::assertEquals(200, $client->getResponse()->getStatusCode());
         $content = $client->getResponse()->getContent();
         self::assertContains('<figure><img src="/uploads/swp/123456/media/20161206161256_383592fef7acb9fc4731a24a691285b7bc51477264a5e343d95c74ccf1d85a93.jpeg"', $content);


### PR DESCRIPTION
# Fixes
When the basic auth was enabled on the server-side, the Publisher was returning `{“status”:403,“message”:“Username could not be found.“}` error on all routes because the Authorization header was added by enabling the basic auth.

## Proposed Changes

TokenAuthorization should be supported only in the API.

License: AGPLv3
