### PR TITLE
fixed date times when null and export only published articles

### DIFF
--- a/src/SWP/Bundle/CoreBundle/AnalyticsExport/ExportAnalyticsHandler.php
+++ b/src/SWP/Bundle/CoreBundle/AnalyticsExport/ExportAnalyticsHandler.php
@@ -22,6 +22,7 @@ use SWP\Bundle\CoreBundle\AnalyticsExport\Exception\AnalyticsReportNotFoundExcep
 use SWP\Bundle\CoreBundle\Context\CachedTenantContextInterface;
 use SWP\Bundle\CoreBundle\Model\AnalyticsReportInterface;
 use SWP\Bundle\CoreBundle\Model\Article;
+use SWP\Bundle\CoreBundle\Model\ArticleInterface;
 use SWP\Bundle\ElasticSearchBundle\Criteria\Criteria;
 use SWP\Component\Common\Model\DateTime;
 use SWP\Component\MultiTenancy\Repository\TenantRepositoryInterface;
@@ -92,11 +93,12 @@ final class ExportAnalyticsHandler implements MessageHandlerInterface
                 $exportAnalytics->getTerm(),
                 [
                     'sort' => ['articleStatistics.pageViewsNumber' => 'desc'],
-                    'publishedBefore' => new \DateTime($exportAnalytics->getEnd()),
-                    'publishedAfter' => new \DateTime($exportAnalytics->getStart()),
+                    'publishedBefore' => '' !== $exportAnalytics->getEnd() ? new \DateTime($exportAnalytics->getEnd()) : null,
+                    'publishedAfter' => '' !== $exportAnalytics->getStart() ? new \DateTime($exportAnalytics->getStart()) : null,
                     'tenantCode' => $tenantCode,
                     'routes' => $exportAnalytics->getRouteIds(),
                     'authors' => $exportAnalytics->getAuthors(),
+                    'statuses' => [ArticleInterface::STATUS_PUBLISHED],
                 ]
             );
 
@@ -123,6 +125,9 @@ final class ExportAnalyticsHandler implements MessageHandlerInterface
             $analyticsReport->setStatus(AnalyticsReportInterface::STATUS_COMPLETED);
         } catch (Throwable $e) {
             $analyticsReport->setStatus(AnalyticsReportInterface::STATUS_ERRORED);
+            $this->analyticsReportRepository->flush();
+
+            throw $e;
         }
 
         $analyticsReport->setUpdatedAt(DateTime::getCurrentDateTime());


### PR DESCRIPTION
Fixes #
SWP-1927

## Proposed Changes

  - when start and end params are not provided it should fallback to null by default so the articles are loaded based on other criteria

License: AGPLv3
