### PR TITLE
use sync queues in dev env

### DIFF
--- a/config/packages/dev/messenger.yaml
+++ b/config/packages/dev/messenger.yaml
@@ -1,0 +1,20 @@
+framework:
+    messenger:
+        failure_transport: failed
+
+        transports:
+            failed: 'doctrine://default?table_name=swp_failed_queue&queue_name=failed'
+            sync_analytics_event: 'sync://'
+            sync_analytics_export: 'sync://'
+            sync_webhooks: 'sync://'
+            sync_content_push: 'sync://'
+            sync_image_conversion: 'sync://'
+            sync_migration_content_push: 'sync://'
+
+        routing:
+            'SWP\Bundle\CoreBundle\AnalyticsExport\ExportAnalytics': sync_analytics_export
+            'SWP\Bundle\AnalyticsBundle\Messenger\AnalyticsEvent': sync_analytics_event
+            'SWP\Bundle\CoreBundle\Webhook\Message\WebhookMessage': sync_webhooks
+            'SWP\Bundle\CoreBundle\MessageHandler\Message\ContentPushMessage': sync_content_push
+            'SWP\Bundle\CoreBundle\MessageHandler\Message\ContentPushMigrationMessage': sync_migration_content_push
+            'SWP\Bundle\CoreBundle\MessageHandler\Message\ConvertImageMessage': sync_image_conversion


### PR DESCRIPTION
use sync queues in dev env - so rabbit mq instance is not needed locally and in publisher ci tests 


License: AGPLv3
