### PR TITLE
add option to filter article metadata with expression

### DIFF
--- a/docs/cookbooks/developers/content_lists.rst
+++ b/docs/cookbooks/developers/content_lists.rst
@@ -54,6 +54,10 @@ Possible methods are:
 
 - ``containsItem`` - checks if current base is an array and looks for provided key and value match
 
+.. tip::
+
+    Filtering based on expression don't work in case of rebuilding list by filter.
+
 
 All criteria can be combined together which in the result it will add articles to the list (on publish) depending on your needs.
 

--- a/docs/cookbooks/developers/content_lists.rst
+++ b/docs/cookbooks/developers/content_lists.rst
@@ -44,4 +44,17 @@ Built in criteria:
 
 - ``metadata`` - metadata field is json string, e.g. ``{"metadata":{"language":"en"}}``. It matches article's metadata, and you can use all metadata fields that are defined for the article, i.e.: language, located etc.
 
+``metadata`` allows also filtering based on expression. It uses DataFilter class (SWP\Bundle\CoreBundle\Filter\DataFilter) methods for metadata checking.
+
+Example usage: ``{"metadata": "filter.contains('subject').containsItem('code', '001').containsItem('code', '123')"}``
+
+Possible methods are:
+
+- ``contains`` - checks if metadata have provided key and sets is as a base for next methods calls.
+
+- ``containsItem`` - checks if current base is an array and looks for provided key and value match
+
+
 All criteria can be combined together which in the result it will add articles to the list (on publish) depending on your needs.
+
+

--- a/features/content_lists/add_article_to_list_based_on_unordered_subjects.feature
+++ b/features/content_lists/add_article_to_list_based_on_unordered_subjects.feature
@@ -14,7 +14,8 @@ Feature: Add article to automated content lists
     | name                  | type      | filters                           |
     | first content list    | automatic | {"metadata":{}, "route": [1]}     |
     | second content list   | automatic | {"route":[1]}                     |
-    | third content list   | automatic | {"metadata":{"subject":[{"name":"lawyer","scheme":"test","code":"02002001"}]}} |
+    | third content list   | automatic | {"metadata":{"subject":[{"name":"lawyer","scheme":"test","code":"02002001"}, {"code":"001","scheme":"test2","name":"priest"}]}} |
+    | forth content list   | automatic | {"metadata": "filter.contains('subject').containsItem('code', '02002001').containsItem('name', 'priest')"} |
 
 
     Given the following Users:
@@ -74,11 +75,16 @@ Feature: Add article to automated content lists
             "language":"en","headline":"Test Package","version":"2","guid":"16e111d5","priority":6,"type":"text",
             "authors":[{"name":"Tom Doe","role":"editor"}],
             "byline":"Admin",
-            "subject":[{"code":"02002001","scheme":"test","name":"lawyer"}]
+            "subject":[{"code":"02002001","scheme":"test","name":"lawyer"}, {"code":"001","scheme":"test2","name":"priest"}]
         }
         """
 
     And I am authenticated as "test.user"
     And I add "Content-Type" header equal to "application/json"
     Then I send a "GET" request to "/api/v2/content/lists/3/items/"
+    And the JSON node "total" should be equal to "1"
+
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v2/content/lists/4/items/"
     And the JSON node "total" should be equal to "1"

--- a/src/SWP/Bundle/CoreBundle/Filter/DataFilter.php
+++ b/src/SWP/Bundle/CoreBundle/Filter/DataFilter.php
@@ -33,7 +33,7 @@ class DataFilter
         return $this;
     }
 
-    public function reset(): DataFilter
+    public function reset(): self
     {
         $this->currentData = $this->initialData;
     }

--- a/src/SWP/Bundle/CoreBundle/Filter/DataFilter.php
+++ b/src/SWP/Bundle/CoreBundle/Filter/DataFilter.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2020 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2020 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Filter;
+
+use SWP\Bundle\CoreBundle\Filter\Exception\KeyNotExistsException;
+use SWP\Bundle\CoreBundle\Filter\Exception\NotEqualDataException;
+
+class DataFilter
+{
+    protected $currentData;
+
+    protected $initialData;
+
+    public function loadData(array $data): DataFilter
+    {
+        $this->initialData = $data;
+        $this->currentData = $data;
+
+        return $this;
+    }
+
+    public function reset(): DataFilter
+    {
+        $this->currentData = $this->initialData;
+    }
+
+    public function contains(string $key): DataFilter
+    {
+        if (!array_key_exists($key, $this->currentData)) {
+            throw new KeyNotExistsException($key, \array_keys($this->currentData));
+        }
+
+        $this->currentData = $this->currentData[$key];
+
+        return $this;
+    }
+
+    public function containsItem(string $key, $value): DataFilter
+    {
+        $found = false;
+        foreach ($this->currentData as $item) {
+            if (array_key_exists($key, $item) && $item[$key] === $value) {
+                $found = true;
+            }
+        }
+
+        if (!$found) {
+            throw new NotEqualDataException($key, $value);
+        }
+
+        return $this;
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/Filter/DataFilter.php
+++ b/src/SWP/Bundle/CoreBundle/Filter/DataFilter.php
@@ -25,7 +25,7 @@ class DataFilter
 
     protected $initialData;
 
-    public function loadData(array $data): DataFilter
+    public function loadData(array $data): self
     {
         $this->initialData = $data;
         $this->currentData = $data;
@@ -38,7 +38,7 @@ class DataFilter
         $this->currentData = $this->initialData;
     }
 
-    public function contains(string $key): DataFilter
+    public function contains(string $key): self
     {
         if (!array_key_exists($key, $this->currentData)) {
             throw new KeyNotExistsException($key, \array_keys($this->currentData));
@@ -49,7 +49,7 @@ class DataFilter
         return $this;
     }
 
-    public function containsItem(string $key, $value): DataFilter
+    public function containsItem(string $key, $value): self
     {
         $found = false;
         foreach ($this->currentData as $item) {

--- a/src/SWP/Bundle/CoreBundle/Filter/Exception/FilterException.php
+++ b/src/SWP/Bundle/CoreBundle/Filter/Exception/FilterException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2020 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2020 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Filter\Exception;
+
+class FilterException extends \Exception
+{
+}

--- a/src/SWP/Bundle/CoreBundle/Filter/Exception/KeyNotExistsException.php
+++ b/src/SWP/Bundle/CoreBundle/Filter/Exception/KeyNotExistsException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2020 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2020 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Filter\Exception;
+
+class KeyNotExistsException extends FilterException
+{
+    public function __construct(string $key, $currentDataKeys)
+    {
+        parent::__construct(sprintf('Provided key ("%s") does not exists. Possible options are: %s', $key, \json_encode($currentDataKeys)));
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/Filter/Exception/NotEqualDataException.php
+++ b/src/SWP/Bundle/CoreBundle/Filter/Exception/NotEqualDataException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2020 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2020 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Filter\Exception;
+
+class NotEqualDataException extends FilterException
+{
+    public function __construct(string $key, $data)
+    {
+        parent::__construct(sprintf('Checked key ("%s") value is not equal to one provided: "%s"', $key, json_encode($data)));
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/Tests/FIlter/DataFilterTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/FIlter/DataFilterTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2016 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2016 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\Tests\Fragment;
+
+use PHPUnit\Framework\TestCase;
+use SWP\Bundle\CoreBundle\Filter\DataFilter;
+use SWP\Bundle\CoreBundle\Filter\Exception\FilterException;
+use SWP\Bundle\CoreBundle\Filter\Exception\KeyNotExistsException;
+use SWP\Bundle\CoreBundle\Filter\Exception\NotEqualDataException;
+
+final class DataFilterTest extends TestCase
+{
+    private $dataFilter;
+
+    public function setUp()
+    {
+        $this->dataFilter = new DataFilter();
+    }
+
+    public function testFiltering()
+    {
+        $data = \json_decode('{"subject":[{"code":"02002001","scheme":"test","name":"lawyer"}]}', true);
+
+        $result = false;
+        try {
+            $this->dataFilter->loadData($data);
+            $this->dataFilter->contains('subject');
+            $this->dataFilter->containsItem('code', '02002001');
+            $this->dataFilter->containsItem('scheme', 'test');
+            $result = true;
+        } catch (FilterException $e) {
+            // ignore exceptions
+        }
+
+        self::assertTrue($result);
+    }
+
+    public function testKeyNotFound()
+    {
+        $data = \json_decode('{"subject":[{"code":"02002001","scheme":"test","name":"lawyer"}]}', true);
+
+        self::expectException(KeyNotExistsException::class);
+        $this->dataFilter->loadData($data);
+        $this->dataFilter->contains('data');
+    }
+
+    public function testDataNotEqual()
+    {
+        $data = \json_decode('{"subject":[{"code":"02002001","scheme":"test","name":"lawyer"}]}', true);
+
+        self::expectException(NotEqualDataException::class);
+        $this->dataFilter->loadData($data);
+        $this->dataFilter->containsItem('data', 'wrongValue');
+    }
+}

--- a/src/SWP/Bundle/CoreBundle/Tests/FIlter/DataFilterTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/FIlter/DataFilterTest.php
@@ -34,8 +34,8 @@ final class DataFilterTest extends TestCase
     public function testFiltering()
     {
         $data = \json_decode('{"subject":[{"code":"02002001","scheme":"test","name":"lawyer"}]}', true);
-
         $result = false;
+
         try {
             $this->dataFilter->loadData($data);
             $this->dataFilter->contains('subject');

--- a/src/SWP/Component/ContentList/Model/ContentList.php
+++ b/src/SWP/Component/ContentList/Model/ContentList.php
@@ -172,7 +172,7 @@ class ContentList implements ContentListInterface
      */
     public function setFilters(array $filters)
     {
-        if (isset($filters['metadata'])) {
+        if (isset($filters['metadata']) && is_array($filters['metadata'])) {
             $filters['metadata'] = ArrayHelper::sortNestedArrayAssocAlphabeticallyByKey($filters['metadata']);
         }
         $this->filters = $filters;


### PR DESCRIPTION
Allow to catch published article to content list by expression filter.

```
{"metadata": "filter.contains('subject').containsItem('code', '001').containsItem('code', '123')"}
```

License: AGPLv3
