### PR TITLE
set text/html as default response content type for template rendering result

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Controller/ContentController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/ContentController.php
@@ -23,6 +23,9 @@ class ContentController extends AbstractController
 {
     public function renderPageAction(string $contentTemplate): Response
     {
-        return $this->render($contentTemplate);
+        $response = new Response();
+        $response->headers->set('Content-Type', 'text/html; charset=UTF-8');
+
+        return $this->render($contentTemplate, [], $response);
     }
 }

--- a/src/SWP/Bundle/CoreBundle/Controller/DefaultController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/DefaultController.php
@@ -14,13 +14,13 @@
 
 namespace SWP\Bundle\CoreBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Routing\Annotation\Route;
 use SWP\Bundle\ContentBundle\Model\RouteInterface;
 use SWP\Bundle\CoreBundle\Model\TenantInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
 
 class DefaultController extends AbstractController
 {
@@ -48,6 +48,9 @@ class DefaultController extends AbstractController
 
         $templateEngineContext->setCurrentPage($metaFactory->create($route));
 
-        return $this->render('index.html.twig');
+        $response = new Response();
+        $response->headers->set('Content-Type', 'text/html; charset=UTF-8');
+
+        return $this->render('index.html.twig', [], $response);
     }
 }


### PR DESCRIPTION
Do not blindly trust http `Accept` header and built in symfony content negotiation. Instead of that explicitly se content type header in response.

License: AGPLv3
