### PR TITLE
Redirect to dynamic route after successful login

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Controller/ExternalOauthController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/ExternalOauthController.php
@@ -7,18 +7,28 @@ namespace SWP\Bundle\CoreBundle\Controller;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
 
 class ExternalOauthController extends Controller
 {
     public const PUBLISHER_JWT_COOKIE = 'publisher_jwt';
+    public const PUBLISHER_REDIRECT_TO_AFTER_OAUTH = 'publisher_redirect_to_after_oauth';
 
     /**
      * @Route("/connect/oauth", name="connect_oauth_start")
      */
-    public function connectAction(): Response
+    public function connectAction(Request $request, SessionInterface $session): Response
     {
+        if ($request->query->has("redirect_to_route_when_successful")) {
+            $session->set(
+                self::PUBLISHER_REDIRECT_TO_AFTER_OAUTH,
+                $request->query->get("redirect_to_route_when_successful")
+           );
+        }
+
         $clientRegistry = $this->get('knpu.oauth2.registry');
 
         return $clientRegistry
@@ -33,7 +43,7 @@ class ExternalOauthController extends Controller
      *
      * @Route("/connect/oauth/check", name="connect_oauth_check")
      */
-    public function connectCheckAction(JWTTokenManagerInterface $jwtTokenManager): Response
+    public function connectCheckAction(JWTTokenManagerInterface $jwtTokenManager, SessionInterface $session): Response
     {
         // If we didn't log in, something went wrong. Throw an exception!
         if (!($user = $this->getUser())) {
@@ -43,7 +53,13 @@ class ExternalOauthController extends Controller
             return $response;
         }
 
-        $response = $this->redirectToRoute('homepage');
+        if ($session->has(self::PUBLISHER_REDIRECT_TO_AFTER_OAUTH)) {
+            $redirectRoute = $session->remove(self::PUBLISHER_REDIRECT_TO_AFTER_OAUTH);
+            $response = $this->redirect($redirectRoute);
+        } else {
+            $response = $this->redirectToRoute('homepage');
+        }
+        
         $response->headers->setCookie(Cookie::create(self::PUBLISHER_JWT_COOKIE, $jwtTokenManager->create($user)));
 
         return $response;

--- a/src/SWP/Bundle/CoreBundle/Controller/ExternalOauthController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/ExternalOauthController.php
@@ -28,7 +28,7 @@ class ExternalOauthController extends Controller
             ->getClient('external_oauth')
             ->redirect([
                 'openid', 'email', 'profile',
-            ], ["state" => $referer]);
+            ], ['state' => $referer]);
     }
 
     /**

--- a/src/SWP/Bundle/CoreBundle/Controller/ExternalOauthController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/ExternalOauthController.php
@@ -8,14 +8,12 @@ use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
 
 class ExternalOauthController extends Controller
 {
     public const PUBLISHER_JWT_COOKIE = 'publisher_jwt';
-    public const PUBLISHER_REDIRECT_TO_AFTER_OAUTH = 'publisher_redirect_to_after_oauth';
 
     /**
      * @Route("/connect/oauth", name="connect_oauth_start")


### PR DESCRIPTION
Fixes #1115 

## Proposed Changes

  - Start a session to keep track of a route that a user can be redirected to after a successful login

## Why was this PR needed?

Currently, after a successful login, the user is always redirected to the 'homepage' route. It would be nice if users were redirected back to an article if they started the login flow from an article.

## How can I test this PR?

Create a link to the oauth route with the query param `redirect_to_route_when_successful`.

```twig
<a href="{{ path('connect_oauth_start', {'redirect_to_route_when_successful': path(gimme.article)}) }}">Login</a></p>
```


License: AGPLv3
