### PR TITLE
expose twitterMedia and ogMedia values in the seoMetadata object in twig

### DIFF
--- a/app/Resources/meta/seoMetadata.yml
+++ b/app/Resources/meta/seoMetadata.yml
@@ -23,3 +23,9 @@ properties:
   metaMedia:
     description: "SEO Meta image"
     type: Meta
+  twitterMedia:
+    description: "SEO Twitter image"
+    type: Meta
+  ogMedia:
+    description: "SEO OG image"
+    type: Meta


### PR DESCRIPTION
## Fixes
Rendering `twitterMedia` and `ogMedia` returned null values, thus it was not possible to generate the URL for those images using, e.g. `{{url(gimme.article.seoMetadata.twitterMedia)}}`

## Proposed Changes

  - expose twitterMedia and ogMedia values in the seoMetadata object in twig

License: AGPLv3
