### PR TITLE
change item headline to text

### DIFF
--- a/src/SWP/Bundle/BridgeBundle/Resources/config/doctrine-orm/Item.orm.yml
+++ b/src/SWP/Bundle/BridgeBundle/Resources/config/doctrine-orm/Item.orm.yml
@@ -13,7 +13,7 @@ SWP\Component\Bridge\Model\Item:
             type: string
             nullable: true
         headline:
-            type: string
+            type: text
         slugline:
             type: string
             nullable: true

--- a/src/SWP/Bundle/CoreBundle/Migrations/2020/07/Version20200706135942.php
+++ b/src/SWP/Bundle/CoreBundle/Migrations/2020/07/Version20200706135942.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SWP\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200706135942 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE swp_item ALTER headline TYPE TEXT');
+        $this->addSql('ALTER TABLE swp_item ALTER headline DROP DEFAULT');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE swp_item ALTER headline TYPE VARCHAR(255)');
+        $this->addSql('ALTER TABLE swp_item ALTER headline DROP DEFAULT');
+    }
+}


### PR DESCRIPTION
## Proposed Changes

  - change the headline of the item to `text` because the headline can be longer than the default 255 chars limit.

License: AGPLv3
