### PR TITLE
fix route name in theme to prevent duplication conflict on theme install

### DIFF
--- a/src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/theme.json
+++ b/src/SWP/Bundle/FixturesBundle/Resources/themes/DefaultTheme/theme.json
@@ -66,7 +66,7 @@
                 "type": "collection"
             },
             {
-                "name": "sci/tech",
+                "name": "scitech",
                 "slug": "scitech",
                 "type": "collection"
             },
@@ -115,7 +115,7 @@
                     {
                         "name": "scitech",
                         "label": "Sci/Tech",
-                        "route": "sci/tech"
+                        "route": "scitech"
                     },
                     {
                         "name": "health",
@@ -158,7 +158,7 @@
                     {
                         "name": "scitech",
                         "label": "Sci/Tech",
-                        "route": "sci/tech"
+                        "route": "scitech"
                     },
                     {
                         "name": "health",


### PR DESCRIPTION
## Error

`Unique violation: 7 ERROR:  duplicate key value violates unique constraint "prefix_idx"
DETAIL:  Key (staticprefix, tenant_code)=(/scitech, 123abc) already exists.`

## Proposed Changes

change the route name from "sci/tech" to "scitech" which will cause installer to find the existing route from fixtures and reuse it instead of trying to add route with the same key

License: AGPLv3
