### PR TITLE
fixed aws url generator

### DIFF
--- a/src/SWP/Bundle/ContentBundle/Resources/config/asset_aws_storage.yaml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/asset_aws_storage.yaml
@@ -17,7 +17,6 @@ services:
   SWP\Bundle\ContentBundle\Asset\AwsAssetUrlGenerator:
     arguments:
       - '@SWP\Bundle\ContentBundle\Factory\S3ClientFactory'
-      - '%env(resolve:FS_MAIN_ADAPTER)%'
       - '%env(resolve:FS_AWS_S3_BUCKET)%'
       - '%env(resolve:FS_AWS_S3_PREFIX)%'
 


### PR DESCRIPTION
### Fixes:

Because of the invalid parameters passed to the was URL generator class, the URLs to assets hosted on AWS were generated wrongly.

License: AGPLv3
