### PR TITLE
Catch FBIA exceptions

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/services.yml
@@ -283,6 +283,7 @@ services:
             - "@swp.factory.facebook_instant_articles_article"
             - "@swp.repository.facebook_instant_articles_article"
             - "@router"
+            - "@logger"
 
     swp.facebook.listener.instant_articles:
         class: SWP\Bundle\CoreBundle\EventListener\FacebookInstantArticlesListener

--- a/src/SWP/Bundle/CoreBundle/Tests/Service/FacebookInstantArticlesServiceTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/Service/FacebookInstantArticlesServiceTest.php
@@ -17,6 +17,7 @@ namespace SWP\Bundle\CoreBundle\Tests\Service;
 use Facebook\Facebook;
 use Facebook\InstantArticles\Client\Client;
 use Facebook\InstantArticles\Client\InstantArticleStatus;
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use SWP\Bundle\CoreBundle\Model\Article;
 use SWP\Bundle\CoreBundle\Model\FacebookInstantArticlesArticle;
@@ -65,6 +66,7 @@ class FacebookInstantArticlesServiceTest extends TestCase
             $this->createMock(Factory::class),
             $this->facebookInstantArticlesArticleRepository,
             $this->createMock(UrlGenerator::class),
+            $this->createMock(Logger::class),
         ])
         ->getMock();
         $client = $this->createMock(Client::class);
@@ -85,6 +87,7 @@ class FacebookInstantArticlesServiceTest extends TestCase
             $this->createMock(Factory::class, [], [], '', false),
             $this->facebookInstantArticlesArticleRepository,
             $this->createMock(UrlGenerator::class, [], [], '', false),
+            $this->createMock(Logger::class),
         ])
         ->getMock();
         $client = $this->createMock(Client::class);
@@ -108,7 +111,8 @@ class FacebookInstantArticlesServiceTest extends TestCase
             new FacebookInstantArticlesManager($this->facebookManager),
             $this->createMock(Factory::class),
             $this->facebookInstantArticlesArticleRepository,
-            $this->createMock(UrlGenerator::class)
+            $this->createMock(UrlGenerator::class),
+            $this->createMock(Logger::class),
         );
     }
 }


### PR DESCRIPTION
## Fixes 

When submitting the article to FBIA fails for a random reason the article won't be published at all on the website.

## Proposed Changes

  - When the FB could not be reached or there is an error from the FB API, skip adding the article to the FBIA and log the exception message.


License: AGPLv3
