### PR TITLE
Term suggest

### DIFF
--- a/features/twig/loaders/searchresults_loader.feature
+++ b/features/twig/loaders/searchresults_loader.feature
@@ -1,0 +1,38 @@
+@disable-fixtures
+Feature: Working with Search Results Loader
+  In order to work with search results articles
+  As a template implementator
+  I want to be able to get articles from search results
+
+  Scenario: Getting article from search result
+    Given the following Tenants:
+      | organization | name | subdomain | domain_name | enabled | default |
+      | Default      | test |           | localhost   | true    | true    |
+
+    Given the following Articles:
+      | title               | route      | status    |
+      | First Test Article  | Test Route | published |
+      | Second Test Article | Test Route | published |
+      | Third Test Article  | Test Route | published |
+
+    And I render a template with content:
+     """
+        {% gimmelist article from searchResults|limit(app.request.get('limit', 100))
+        |order(app.request.get('field', 'publishedAt'), app.request.get('direction', 'desc')) with {
+        page: app.request.get('page', 1),
+        routes: app.request.get('route', []),
+        term: 'Article',
+        publishedBefore: app.request.get('publishedBefore'),
+        publishedAfter: app.request.get('publishedAfter'),
+        publishedAt: app.request.get('publishedAt'),
+        sources: app.request.get('source', []),
+        authors: app.request.get('author', []),
+        statuses: app.request.get('status', []),
+        metadata: app.request.get('metadata', []),
+        keywords: app.request.get('keywords', []),
+        } %}
+        <h4>{{ article.title }}</h4>
+        <p>{{ article.lead }}</p>
+    {% endgimmelist %}
+     """
+    Then rendered template should contain "Test Article"

--- a/features/twig/loaders/searchresults_loader_term_suggest.feature
+++ b/features/twig/loaders/searchresults_loader_term_suggest.feature
@@ -1,0 +1,52 @@
+@disable-fixtures
+Feature: Working with Search Results Loader Phrase Suggest
+  In order to offer user corrected phrase for better search results
+  As a template implementator
+  I want to be able to display improved search phrase suggest suggestion in the template
+
+  Scenario: Getting article from search result
+    Given the following Tenants:
+      | organization | name | subdomain | domain_name | enabled | default |
+      | Default      | test |           | localhost   | true    | true    |
+
+    Given the following Articles:
+      | title               | route      | status    |
+      | First Test Article  | Test Route | published |
+      | Second Test Article | Test Route | published |
+      | Third Test Article  | Test Route | published |
+
+    And I render a template with content:
+     """
+        {% gimmelist article from searchResults|limit(app.request.get('limit', 100))
+        |order(app.request.get('field', 'publishedAt'), app.request.get('direction', 'desc')) with {
+        page: app.request.get('page', 1),
+        routes: app.request.get('route', []),
+
+        term: 'Artidle',
+
+        publishedBefore: app.request.get('publishedBefore'),
+        publishedAfter: app.request.get('publishedAfter'),
+        publishedAt: app.request.get('publishedAt'),
+        sources: app.request.get('source', []),
+        authors: app.request.get('author', []),
+        statuses: app.request.get('status', []),
+        metadata: app.request.get('metadata', []),
+        keywords: app.request.get('keywords', []),
+        } %}
+
+        {% if searchResults.suggestedTerm %}
+        suggested term: {{ searchResults.suggestedTerm }}
+        {% endif %}
+
+        <h4>{{ article.title }}</h4>
+        <p>{{ article.lead }}</p>
+
+        {% else %}
+        {% if searchResults.suggestedTerm %}
+        suggested term: {{ searchResults.suggestedTerm }}
+        {% endif %}
+
+    {% endgimmelist %}
+     """
+    Then rendered template should not contain "Test Article"
+    And rendered template should contain "suggested term: article"

--- a/src/SWP/Bundle/ElasticSearchBundle/Loader/SearchResultLoader.php
+++ b/src/SWP/Bundle/ElasticSearchBundle/Loader/SearchResultLoader.php
@@ -110,6 +110,8 @@ final class SearchResultLoader implements LoaderInterface
             }
         }
 
+        $metaCollection->suggestedTerm = $repository->getSuggestedTerm($criteria->getTerm());
+
         return $metaCollection;
     }
 

--- a/src/SWP/Bundle/ElasticSearchBundle/Repository/ArticleRepository.php
+++ b/src/SWP/Bundle/ElasticSearchBundle/Repository/ArticleRepository.php
@@ -23,6 +23,7 @@ use Elastica\Query\MultiMatch;
 use Elastica\Query\Nested;
 use Elastica\Query\Range;
 use Elastica\Query\Term;
+use Elastica\QueryBuilder\DSL\Suggest;
 use FOS\ElasticaBundle\Paginator\PaginatorAdapterInterface;
 use FOS\ElasticaBundle\Repository;
 use SWP\Bundle\ElasticSearchBundle\Criteria\Criteria;
@@ -137,5 +138,36 @@ class ArticleRepository extends Repository
         $query->setSize(SearchResultLoader::MAX_RESULTS);
 
         return $this->createPaginatorAdapter($query);
+    }
+
+
+    public function getSuggestedTerm(string $term): string
+    {
+        $suggestQuery = new Suggest();
+        $suggestQuery->phrase('our_suggestion', '_all');
+
+        $phraseMultiMatchQuery = new MultiMatch();
+        $phraseMultiMatchQuery->setQuery($term);
+        $phraseMultiMatchQuery->setFields('_all');
+        $phraseMultiMatchQuery->setType(MultiMatch::TYPE_PHRASE);
+        $phraseMultiMatchQuery->setParam('boost', 50);
+
+        $query = new \Elastica\Query($phraseMultiMatchQuery);
+        $suggest = new \Elastica\Suggest();
+        $suggest->setParam(
+            'phrase',
+            [
+                'text' => $term,
+                'phrase' => ['field' => '_all']
+            ]
+        );
+
+        $query->setSuggest($suggest);
+
+        $adapter = $this->createPaginatorAdapter($query);
+        $suggest = $adapter->getSuggests();
+
+        return $suggest['phrase'][0]['options'][0]['text'] ?? '';
+
     }
 }


### PR DESCRIPTION
Provides fuzzy search term fixing. 
When elastic search finds better phrase it is provided to the user.

In  template it can be then use like this: 

```
Did you mean <a href="{{ path(app.request.attributes.get('_route'),
            app.request.query.all|merge({'q': searchResults.suggestedTerm}))|replace({'%20': '+'})  }}">{{ searchResults.suggestedTerm }}</a> ?
```

License: AGPLv3
