### PR TITLE
Attach article to content route on article publish

### DIFF
--- a/features/02_articles/article_attach_to_content_route.feature
+++ b/features/02_articles/article_attach_to_content_route.feature
@@ -1,0 +1,112 @@
+@articles
+@disable-fixtures
+Feature: Article attach to content route on publish
+
+  Scenario: Check if an article has been attached to content route successfully
+    Given the following Tenants:
+      | organization | name | subdomain | domainName | enabled | default  | themeName      |  code   |
+      | Default      | test |           | localhost  | true    | true     | swp/test-theme | 123abc  |
+
+    Given the following Routes:
+      |  name | type       | slug |
+      |  test | content    | test |
+
+    Given the following Users:
+      | username   | email                      | token      | plainPassword | role                | enabled |
+      | test.user  | test.user@sourcefabric.org | test_user: | testPassword  | ROLE_INTERNAL_API   | true    |
+
+    Given the following organization publishing rule:
+    """
+      {
+        "name":"Test rule",
+        "description":"Test rule description",
+        "priority":1,
+        "expression":"true == true",
+        "configuration":[
+          {
+            "key":"destinations",
+            "value":[
+              {
+                "tenant":"123abc"
+              }
+            ]
+          }
+        ]
+      }
+    """
+
+    Given the following tenant publishing rule:
+    """
+      {
+          "name":"Test tenant rule",
+          "description":"Test tenant rule description",
+          "priority":1,
+          "expression":"article.getPackage().getLanguage() == 'en'",
+          "configuration":[
+            {
+              "key":"route",
+              "value":1
+            },
+            {
+              "key":"published",
+              "value":true
+            }
+          ]
+       }
+    """
+
+    Given the following Package ninjs:
+    """
+    {
+      "language":"en",
+      "slugline":"lorem",
+      "body_html":"<p>some html body</p>",
+      "versioncreated":"2016-09-23T13:57:28+0000",
+      "firstcreated":"2016-05-25T10:23:15+0000",
+      "description_text":"some abstract text",
+      "profile":"Article",
+      "place":[
+        {
+          "country":"Australia",
+          "world_region":"Oceania",
+          "state":"Australian Capital Territory",
+          "qcode":"ACT",
+          "name":"ACT",
+          "group":"Australia"
+        }
+      ],
+      "version":"2",
+      "byline":"ADmin",
+      "keywords":[
+        "keyword1",
+        "keyword2"
+      ],
+      "guid":"urn:newsml:localhost:2016-09-23T13:56:39.404843:56465de4-0d5c-495a-8e36-3b396def3cf0",
+      "priority":6,
+      "subject":[
+        {
+          "name":"lawyer",
+          "code":"02002001"
+        }
+      ],
+      "urgency":3,
+      "type":"text",
+      "headline":"Lorem",
+      "service":[
+        {
+          "name":"Australian General News",
+          "code":"a"
+        }
+      ],
+      "description_html":"<p><b><u>some abstract text</u></b></p>",
+      "located":"Warsaw",
+      "pubstatus":"usable"
+    }
+    """
+
+    Then I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v2/content/routes/1"
+    Then the response status code should be 200
+    And the JSON node "content.title" should contain "Lorem"
+

--- a/features/02_articles/article_attach_to_content_route.feature
+++ b/features/02_articles/article_attach_to_content_route.feature
@@ -4,16 +4,16 @@ Feature: Article attach to content route on publish
 
   Scenario: Check if an article has been attached to content route successfully
     Given the following Tenants:
-      | organization | name | subdomain | domainName | enabled | default  | themeName      |  code   |
-      | Default      | test |           | localhost  | true    | true     | swp/test-theme | 123abc  |
+      | organization | name | subdomain | domainName | enabled | default | themeName      | code   |
+      | Default      | test |           | localhost  | true    | true    | swp/test-theme | 123abc |
 
     Given the following Routes:
-      |  name | type       | slug |
-      |  test | content    | test |
+      | name | type    | slug |
+      | test | content | test |
 
     Given the following Users:
-      | username   | email                      | token      | plainPassword | role                | enabled |
-      | test.user  | test.user@sourcefabric.org | test_user: | testPassword  | ROLE_INTERNAL_API   | true    |
+      | username  | email                      | token      | plainPassword | role              | enabled |
+      | test.user | test.user@sourcefabric.org | test_user: | testPassword  | ROLE_INTERNAL_API | true    |
 
     Given the following organization publishing rule:
     """
@@ -110,3 +110,23 @@ Feature: Article attach to content route on publish
     Then the response status code should be 200
     And the JSON node "content.title" should contain "Lorem"
 
+  Scenario: Check if an article has been detached from content route successfully
+    When I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "PATCH" request to "/api/v2/content/articles/lorem" with body:
+     """
+      {
+          "status": "unpublished"
+      }
+     """
+    Then the response status code should be 200
+    And I am authenticated as "test.user"
+    And I add "Content-Type" header equal to "application/json"
+    Then I send a "GET" request to "/api/v2/content/articles/lorem"
+    Then the response status code should be 200
+    And the JSON node "slug" should be equal to "lorem"
+    And the JSON node "status" should be equal to "unpublished"
+    Then I am authenticated as "test.user"
+    And I send a "GET" request to "/api/v2/content/routes/1"
+    Then the response status code should be 200
+    And the JSON node "content" should be null

--- a/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
+++ b/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
@@ -26,7 +26,7 @@ class AttachArticleToContentRouteListener
         $article = $articleEvent->getArticle();
         $route = $articleEvent->getArticle()->getRoute();
 
-        if(RouteInterface::TYPE_CONTENT === $route->getType()) {
+        if($route && RouteInterface::TYPE_CONTENT === $route->getType()) {
             $route->setContent($article);
             $this->routeRepository->persist($route);
             $this->routeRepository->flush();
@@ -39,7 +39,7 @@ class AttachArticleToContentRouteListener
 
         $route = $articleEvent->getArticle()->getRoute();
 
-        if(RouteInterface::TYPE_CONTENT === $route->getType()) {
+        if($route && RouteInterface::TYPE_CONTENT === $route->getType()) {
             $route->setContent(null);
             $this->routeRepository->persist($route);
             $this->routeRepository->flush();

--- a/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
+++ b/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
@@ -25,8 +25,9 @@ class AttachArticleToContentRouteListener
         /** @var ArticleInterface $article */
         $article = $articleEvent->getArticle();
         $route = $articleEvent->getArticle()->getRoute();
+        $alreadyAttachedRoute = $this->routeRepository->findOneBy(['content' => $article]);
 
-        if($route && RouteInterface::TYPE_CONTENT === $route->getType()) {
+        if($route && !$alreadyAttachedRoute &&  RouteInterface::TYPE_CONTENT === $route->getType()) {
             $route->setContent($article);
             $this->routeRepository->persist($route);
             $this->routeRepository->flush();

--- a/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
+++ b/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
@@ -1,5 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Content Bundle.
+ *
+ * Copyright 2019 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2019 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
 
 namespace SWP\Bundle\ContentBundle\EventListener;
 
@@ -11,7 +24,7 @@ use SWP\Bundle\CoreBundle\Model\ArticleInterface;
 class AttachArticleToContentRouteListener
 {
 
-    /** @var RouteRepositoryInterface  */
+    /** @var RouteRepositoryInterface */
     private $routeRepository;
 
     public function __construct(RouteRepositoryInterface $routeRepository)
@@ -24,15 +37,13 @@ class AttachArticleToContentRouteListener
     {
         /** @var ArticleInterface $article */
         $article = $articleEvent->getArticle();
-        $route = $articleEvent->getArticle()->getRoute();
+        $route = $article->getRoute();
         $alreadyAttachedRoute = $this->routeRepository->findOneBy(['content' => $article]);
 
-        if($route && !$alreadyAttachedRoute &&  RouteInterface::TYPE_CONTENT === $route->getType()) {
+        if (null !== $route && !$alreadyAttachedRoute && RouteInterface::TYPE_CONTENT === $route->getType()) {
             $route->setContent($article);
-            $this->routeRepository->persist($route);
             $this->routeRepository->flush();
         }
-
     }
 
     public function onArticleUnpublish(ArticleEvent $articleEvent): void
@@ -40,12 +51,9 @@ class AttachArticleToContentRouteListener
 
         $route = $articleEvent->getArticle()->getRoute();
 
-        if($route && RouteInterface::TYPE_CONTENT === $route->getType()) {
+        if ($route && RouteInterface::TYPE_CONTENT === $route->getType()) {
             $route->setContent(null);
-            $this->routeRepository->persist($route);
             $this->routeRepository->flush();
         }
-
     }
-
 }

--- a/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
+++ b/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace SWP\Bundle\ContentBundle\EventListener;
+
+use SWP\Bundle\ContentBundle\Event\ArticleEvent;
+use SWP\Bundle\ContentBundle\Model\RouteInterface;
+use SWP\Bundle\ContentBundle\Model\RouteRepositoryInterface;
+use SWP\Bundle\CoreBundle\Model\ArticleInterface;
+
+class AttachArticleToContentRouteListener
+{
+
+    private RouteRepositoryInterface $routeRepository;
+
+    public function __construct(RouteRepositoryInterface $routeRepository)
+    {
+
+        $this->routeRepository = $routeRepository;
+    }
+
+    public function onArticlePublish(ArticleEvent $articleEvent): void
+    {
+        /** @var ArticleInterface $article */
+        $article = $articleEvent->getArticle();
+        $route = $articleEvent->getArticle()->getRoute();
+
+        if(RouteInterface::TYPE_CONTENT === $route->getType()) {
+            $route->setContent($article);
+            $this->routeRepository->persist($route);
+            $this->routeRepository->flush();
+        }
+
+    }
+
+    public function onArticleUnpublish(ArticleEvent $articleEvent): void
+    {
+
+        $route = $articleEvent->getArticle()->getRoute();
+
+        if(RouteInterface::TYPE_CONTENT === $route->getType()) {
+            $route->setContent(null);
+            $this->routeRepository->persist($route);
+            $this->routeRepository->flush();
+        }
+
+    }
+
+}

--- a/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
+++ b/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
@@ -11,7 +11,8 @@ use SWP\Bundle\CoreBundle\Model\ArticleInterface;
 class AttachArticleToContentRouteListener
 {
 
-    private RouteRepositoryInterface $routeRepository;
+    /** @var RouteRepositoryInterface  */
+    private $routeRepository;
 
     public function __construct(RouteRepositoryInterface $routeRepository)
     {

--- a/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
+++ b/src/SWP/Bundle/ContentBundle/EventListener/AttachArticleToContentRouteListener.php
@@ -23,13 +23,11 @@ use SWP\Bundle\CoreBundle\Model\ArticleInterface;
 
 class AttachArticleToContentRouteListener
 {
-
     /** @var RouteRepositoryInterface */
     private $routeRepository;
 
     public function __construct(RouteRepositoryInterface $routeRepository)
     {
-
         $this->routeRepository = $routeRepository;
     }
 
@@ -48,7 +46,6 @@ class AttachArticleToContentRouteListener
 
     public function onArticleUnpublish(ArticleEvent $articleEvent): void
     {
-
         $route = $articleEvent->getArticle()->getRoute();
 
         if ($route && RouteInterface::TYPE_CONTENT === $route->getType()) {

--- a/src/SWP/Bundle/ContentBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/services.yml
@@ -144,6 +144,14 @@ services:
         tags:
             - { name: kernel.event_listener, event: swp.article.pre_create, method: onArticleCreate }
 
+    SWP\Bundle\ContentBundle\EventListener\AttachArticleToContentRouteListener:
+        arguments:
+            - '@swp.repository.route'
+        tags:
+            - { name: kernel.event_listener, event: swp.article.published, method: onArticlePublish }
+            - { name: kernel.event_listener, event: swp.article.unpublished, method: onArticleUnpublish }
+#            - { name: kernel.event_listener, event: swp.article.canceled, method: onArticleCancel }
+
     swp_content_bundle.key_generator.meta_key_generator:
         class: SWP\Bundle\ContentBundle\KeyGenerator\MetaKeyGenerator
 

--- a/src/SWP/Bundle/ContentBundle/Resources/config/services.yml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/services.yml
@@ -150,7 +150,6 @@ services:
         tags:
             - { name: kernel.event_listener, event: swp.article.published, method: onArticlePublish }
             - { name: kernel.event_listener, event: swp.article.unpublished, method: onArticleUnpublish }
-#            - { name: kernel.event_listener, event: swp.article.canceled, method: onArticleCancel }
 
     swp_content_bundle.key_generator.meta_key_generator:
         class: SWP\Bundle\ContentBundle\KeyGenerator\MetaKeyGenerator

--- a/src/SWP/Bundle/ContentBundle/spec/EventListener/AttachArticleToContentRouteListenerSpec.php
+++ b/src/SWP/Bundle/ContentBundle/spec/EventListener/AttachArticleToContentRouteListenerSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace spec\SWP\Bundle\ContentBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use SWP\Bundle\ContentBundle\Model\RouteRepositoryInterface;
+
+class AttachArticleToContentRouteListenerSpec extends ObjectBehavior
+{
+
+    public function let(RouteRepositoryInterface $routeRepository)
+    {
+        $this->beConstructedWith($routeRepository);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType('SWP\Bundle\ContentBundle\EventListener\AttachArticleToContentRouteListener');
+    }
+}

--- a/src/SWP/Bundle/ContentBundle/spec/EventListener/AttachArticleToContentRouteListenerSpec.php
+++ b/src/SWP/Bundle/ContentBundle/spec/EventListener/AttachArticleToContentRouteListenerSpec.php
@@ -7,7 +7,6 @@ use SWP\Bundle\ContentBundle\Model\RouteRepositoryInterface;
 
 class AttachArticleToContentRouteListenerSpec extends ObjectBehavior
 {
-
     public function let(RouteRepositoryInterface $routeRepository)
     {
         $this->beConstructedWith($routeRepository);


### PR DESCRIPTION
Fixes #
When publishing an article to content type of route, we also need to assign its id to route's 'content' property. 
Only then that article appears on frontend as content of that route.


License: AGPLv3
