### PR TITLE
set x-forwarded-for from x-real-ip header

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -19,6 +19,8 @@ if ($_SERVER['APP_DEBUG']) {
     Debug::enable();
 }
 
+$_SERVER['HTTP_X_FORWARDED_FOR'] = $_SERVER['HTTP_X_REAL_IP'];
+
 if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
     Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
 }


### PR DESCRIPTION
## Reasons
Properly detect client real IP in Publisher for the geolocation feature. When the app is behind the proxy the real client IP address is the IP of the proxy.

## Proposed Changes

  - set value of `x-forwarded-for` header from `x-real-ip` header

License: AGPLv3
