### PR TITLE
Fix _swp_analytics endpoint and sorting by page views

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use App\Kernel;
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
 require dirname(__DIR__).'/config/bootstrap.php';

--- a/src/SWP/Bundle/CoreBundle/Resources/config/message_handlers.yaml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/message_handlers.yaml
@@ -16,6 +16,7 @@ services:
             - '@swp_multi_tenancy.tenant_resolver'
             - '@swp_multi_tenancy.tenant_context'
             - '@swp.object_manager.article_statistics'
+            - '@fos_elastica.object_persister.swp.article'
 
     SWP\Bundle\CoreBundle\MessageHandler\ContentPushHandler:
         arguments:

--- a/src/SWP/Bundle/CoreBundle/Service/ArticleStatisticsService.php
+++ b/src/SWP/Bundle/CoreBundle/Service/ArticleStatisticsService.php
@@ -71,6 +71,7 @@ class ArticleStatisticsService implements ArticleStatisticsServiceInterface
         if (null === $article) {
             return;
         }
+        $articleStatistics->setArticle($article);
 
         $this->articleStatisticsRepository->add($articleStatistics);
     }


### PR DESCRIPTION
## Reasons

_swp_analytics endpoint was broken for new pageviews and articles were not sorted correctly by pageviews because of elasticsearch index not being updated on pageview update



License: AGPLv3
