### PR TITLE
force retry when the lock is aquired

### DIFF
--- a/src/SWP/Bundle/CoreBundle/MessageHandler/Exception/LockConflictedException.php
+++ b/src/SWP/Bundle/CoreBundle/MessageHandler/Exception/LockConflictedException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher Core Bundle.
+ *
+ * Copyright 2021 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2021 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\CoreBundle\MessageHandler\Exception;
+
+final class LockConflictedException extends \RuntimeException
+{
+}

--- a/src/SWP/Bundle/CoreBundle/MessageHandler/ImageConversionHandler.php
+++ b/src/SWP/Bundle/CoreBundle/MessageHandler/ImageConversionHandler.php
@@ -53,6 +53,8 @@ class ImageConversionHandler implements MessageHandlerInterface
 
     protected $entityManager;
 
+    protected $lockFactory;
+
     public function __construct(
         SerializerInterface $serializer,
         LoggerInterface $logger,

--- a/src/SWP/Bundle/CoreBundle/MessageHandler/ImageConversionHandler.php
+++ b/src/SWP/Bundle/CoreBundle/MessageHandler/ImageConversionHandler.php
@@ -20,6 +20,7 @@ use BadFunctionCallException;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
+use SWP\Bundle\CoreBundle\MessageHandler\Exception\LockConflictedException;
 use Symfony\Component\Lock\LockFactory;
 use Throwable;
 use function imagewebp;

--- a/src/SWP/Bundle/CoreBundle/Resources/config/message_handlers.yaml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/message_handlers.yaml
@@ -35,3 +35,4 @@ services:
             - '@jms_serializer'
             - '@monolog.logger.swp_image_conversion'
             - '@swp.repository.image_rendition'
+            - '@lock.factory'

--- a/src/SWP/Bundle/CoreBundle/Resources/config/message_handlers.yaml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/message_handlers.yaml
@@ -35,4 +35,3 @@ services:
             - '@jms_serializer'
             - '@monolog.logger.swp_image_conversion'
             - '@swp.repository.image_rendition'
-            - '@lock.factory'

--- a/src/SWP/Bundle/CoreBundle/Resources/config/message_handlers.yaml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/message_handlers.yaml
@@ -9,6 +9,7 @@ services:
         exclude: '../../MessageHandler/Message/*'
         bind:
             $jsonToPackageTransformer: '@swp_bridge.transformer.json_to_package'
+            $lockFactory: '@lock.factory'
 
     SWP\Bundle\CoreBundle\MessageHandler\AnalyticsEventHandler:
         arguments:
@@ -28,7 +29,6 @@ services:
             - '@swp_multi_tenancy.tenant_context'
             - '@Sentry\State\HubInterface'
             - '@SWP\Bundle\CoreBundle\Hydrator\PackageHydratorInterface'
-            - '@lock.factory'
 
     SWP\Bundle\CoreBundle\MessageHandler\ImageConversionHandler:
         arguments:

--- a/src/SWP/Bundle/CoreBundle/Resources/config/message_handlers.yaml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/message_handlers.yaml
@@ -28,6 +28,7 @@ services:
             - '@swp_multi_tenancy.tenant_context'
             - '@Sentry\State\HubInterface'
             - '@SWP\Bundle\CoreBundle\Hydrator\PackageHydratorInterface'
+            - '@lock.factory'
 
     SWP\Bundle\CoreBundle\MessageHandler\ImageConversionHandler:
         arguments:


### PR DESCRIPTION
## Reasons

It should not be possible to modify the same article once it's being processed by one of the workers. Currently, the webp images are processed concurrently and one process tries to update the same article but its version is older than the one in the elasticsearch, thus it results in throwing errors on the elasticsearch `version conflict, current version [8] is different than the one provided [7]` causing the delays in showing up the articles in the ES index.

## Proposed Changes
- force retry when the lock is already acquired by one of the processes.

License: AGPLv3
