### PR TITLE
ES- Added asciifolding analyzer to package fields

### DIFF
--- a/src/SWP/Bundle/ElasticSearchBundle/Repository/PackageRepository.php
+++ b/src/SWP/Bundle/ElasticSearchBundle/Repository/PackageRepository.php
@@ -155,6 +155,7 @@ class PackageRepository extends Repository
 
         $query = Query::create($functionScore)
             ->addSort([
+                '_score' => 'desc',
                 $criteria->getOrder()->getField() => $criteria->getOrder()->getDirection(),
             ]);
 

--- a/src/SWP/Bundle/ElasticSearchBundle/Resources/config/app/config.yml
+++ b/src/SWP/Bundle/ElasticSearchBundle/Resources/config/app/config.yml
@@ -107,13 +107,13 @@ fos_elastica:
                     properties:
                         id: { type: integer}
                         guid: { type: string, analyzer: swp_code_analyzer }
-                        headline: { type: string }
+                        headline: { type: string, analyzer: swp_folding_analyzer }
                         slugline: { type: string }
                         language: { type: string }
-                        description: { type: string }
-                        byline: { type: string }
+                        description: { type: string, analyzer: swp_folding_analyzer }
+                        byline: { type: string, analyzer: swp_folding_analyzer }
                         status: { type: string }
-                        source: { type: string }
+                        source: { type: string, analyzer: swp_folding_analyzer }
                         updatedAt:
                             type: date
                         organization:


### PR DESCRIPTION
## Reasons

Searching by phrases that contain diacritical marks doesn't work.

For example, typing a phrase with `à` will not return any results in the packages search API.

## Proposed Changes

Apply `swp_folding_analyzer` analyzer to package fields in ES mapping to drop the diacritical marks
License: AGPLv3
