### PR TITLE
get client original extension from file as a fallback

### DIFF
--- a/src/SWP/Bundle/ContentBundle/Manager/MediaManager.php
+++ b/src/SWP/Bundle/ContentBundle/Manager/MediaManager.php
@@ -122,10 +122,11 @@ class MediaManager implements MediaManagerInterface
     private function guessExtension(UploadedFile $uploadedFile): string
     {
         $extension = $uploadedFile->guessExtension();
-        if ('mpga' === $extension && 'mp3' === $uploadedFile->getClientOriginalExtension()) {
+        $clientOriginalExtension = $uploadedFile->getClientOriginalExtension();
+        if ('mpga' === $extension && 'mp3' === $clientOriginalExtension) {
             $extension = 'mp3';
         }
 
-        return $extension;
+        return null !== $extension ? $extension : $clientOriginalExtension;
     }
 }


### PR DESCRIPTION
## Reasons

`guessExtension` doesn't guarantee the returned extension. For some of the images, it can't guess it and the function returns null although it expects a string.

## Proposed Changes
- `getClientOriginalExtension` as a file extension fallback 

License: AGPLv3
