### PR TITLE
Fixed ES weights & license fixes

### DIFF
--- a/src/SWP/Bundle/ElasticSearchBundle/Repository/PackageRepository.php
+++ b/src/SWP/Bundle/ElasticSearchBundle/Repository/PackageRepository.php
@@ -133,7 +133,7 @@ class PackageRepository extends Repository
         $now = new \DateTime();
         $functionScore->addDecayFunction(
             Query\FunctionScore::DECAY_GAUSS,
-            'publishedAt',
+            'updatedAt',
             $now->format('Y-m-d'),
             '31d',
             '1d',
@@ -143,7 +143,7 @@ class PackageRepository extends Repository
 
         $functionScore->addDecayFunction(
             Query\FunctionScore::DECAY_GAUSS,
-            'publishedAt',
+            'updatedAt',
             $now->format('Y-m-d'),
             '365d',
             '1d',

--- a/src/SWP/Component/Bridge/Model/License.php
+++ b/src/SWP/Component/Bridge/Model/License.php
@@ -28,12 +28,12 @@ class License
         $this->url = $url;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getUrl(): string
+    public function getUrl(): ?string
     {
         return $this->url;
     }


### PR DESCRIPTION
## Reasons

## Proposed Changes
- assign weights properly
- allow returning null values for license name and URL when it's not set

License: AGPLv3
