### PR TITLE
fix for doctrine bundle 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "behat/transliterator": "^1.3",
         "burgov/key-value-form-bundle": "^1.6",
         "cboden/ratchet": "^0.4.2",
-        "doctrine/doctrine-bundle": "~1.12",
+        "doctrine/doctrine-bundle": "~1.12.13",
         "doctrine/doctrine-cache-bundle": "1.3.*",
         "doctrine/doctrine-migrations-bundle": "^1.3",
         "doctrine/inflector": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dfbe08b7e702f620afb35ef3d084b11f",
+    "content-hash": "9f59a3d21be6d2387f29d552feb28d68",
     "packages": [
         {
             "name": "apache/log4php",


### PR DESCRIPTION
## Reasons
Fix for error "The DoctrineBundle is not registered in your application. Try running \"composer require symfony\/orm-pack\"


License: AGPLv3
