### PR TITLE
limit querying public search API endpoint

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -44,7 +44,7 @@ security:
             stateless: true
             anonymous: true
         article_search:
-            pattern: ^/api/[v0-9]{2}/content/articles
+            pattern: ^/api/[v0-9]{2}/search/articles/
             stateless: true
             anonymous: true
             security: false

--- a/features/search/public_search_api_endpoint.feature
+++ b/features/search/public_search_api_endpoint.feature
@@ -1,0 +1,183 @@
+@disable-fixtures
+Feature: Public Search API endpoint
+
+  Scenario: Return data from public search API enpoint
+    Given the following Tenants:
+      | organization | name | code   | subdomain | domain_name | enabled | default |
+      | Default      | test | 123abc |           | localhost   | true    | true    |
+
+    Given the following Routes:
+      | name      | type       | slug     |
+      | Tech News | collection | technews |
+
+    And the current date time is "2021-03-15T09:46:13+00:00"
+
+    Given the following Package ninjs:
+    """
+    {
+      "located":"Warsaw",
+      "profile":"583d545634d0c100405d84d2",
+      "version":"3",
+      "type":"text",
+      "slugline":"feature media item",
+      "priority":6,
+      "description_html":"<p>abstract</p>",
+      "guid":"urn:newsml:localhost:2017-02-07T07:46:48.027116:2cde1d3f-302f-4cf9-a4b9-809d2320cc00",
+      "pubstatus":"usable",
+      "associations":{
+        "featuremedia":{
+          "subject":[
+            {
+              "code":"05004000",
+              "name":"preschool"
+            }
+          ],
+          "type":"picture",
+          "usageterms":"indefinite-usage",
+          "priority":6,
+          "renditions":{
+            "original":{
+              "width":2048,
+              "mimetype":"image/jpeg",
+              "poi":{
+                "x":1228,
+                "y":586
+              },
+              "media":"20170111140132/979ff3c8a001d6cb2a7071eab9be852211853990f8d60e693e38f79e972772ea.jpg",
+              "height":1365,
+              "href":"http://localhost:3000/api/upload/979ff3c8a001d6cb2a7071eab9be852211853990f8d60e693e38f79e972772ea/raw"
+            }
+          },
+          "place":[
+
+          ],
+          "pubstatus":"usable",
+          "slugline":"gradac",
+          "firstcreated":"2017-01-11T14:32:58+0000",
+          "mimetype":"image/jpeg",
+          "service":[
+            {
+              "code":"news",
+              "name":"News"
+            }
+          ],
+          "byline":"Ljub. Z. Rankovi\u0107",
+          "urgency":3,
+          "language":"en",
+          "headline":"Smoke on the water",
+          "versioncreated":"2017-01-11T14:52:05+0000",
+          "description_text":"Smoke on the water on River Gradac",
+          "guid":"tag:localhost:2017:4bea4f26-d5a1-446b-8953-3096c0ad0f09",
+          "body_text":"Gradac alt text",
+          "version":"5",
+          "copyrightnotice": "Notice",
+          "copyrightholder": "Holder"
+        }
+      },
+      "place":[
+
+      ],
+      "firstcreated":"2017-02-07T07:46:48+0000",
+      "body_html":"<p>some text and</p><p>footer content</p>",
+      "service":[
+        {
+          "code":"news",
+          "name":"News"
+        }
+      ],
+      "authors":[
+        {
+          "name":"Admin Person",
+          "role":"featured",
+          "biography":"",
+          "avatar_url":"http://localhost:3000/api/upload/1234567890987654321b.jpg"
+        }
+      ],
+      "description_text":"abstract",
+      "urgency":3,
+      "language":"en",
+      "headline":"headline",
+      "byline":"ADmin",
+      "versioncreated":"2017-02-07T07:49:48+0000"
+    }
+    """
+
+    And I publish the submitted package "urn:newsml:localhost:2017-02-07T07:46:48.027116:2cde1d3f-302f-4cf9-a4b9-809d2320cc00":
+    """
+      {
+          "destinations":[
+            {
+              "tenant":"123abc",
+              "published":true,
+              "route": 1
+            }
+          ]
+      }
+    """
+
+    When I send a GET request to "/api/v2/search/articles/"
+    Then the response status code should be 200
+    And the JSON should be equal to:
+    """
+    {
+       "page":1,
+       "limit":10,
+       "pages":1,
+       "total":5,
+       "_links":{
+          "self":{
+             "href":"/api/v2/search/articles/?page=1&limit=10"
+          },
+          "first":{
+             "href":"/api/v2/search/articles/?page=1&limit=10"
+          },
+          "last":{
+             "href":"/api/v2/search/articles/?page=1&limit=10"
+          }
+       },
+       "_embedded":{
+          "_items":[
+             {
+                "title":"headline",
+                "body":"<p>some text and</p><p>footer content</p>",
+                "slug":"feature-media-item",
+                "published_at":"2021-03-15T09:46:13+00:00",
+                "route":{
+                   "name":"Tech News",
+                   "slug":"technews"
+                },
+                "lead":"abstract",
+                "slideshows":[
+
+                ],
+                "updated_at":"2021-03-15T09:46:13+00:00",
+                "authors":[
+                   {
+                      "name":"Admin Person",
+                      "role":"featured",
+                      "slug":"admin-person",
+                      "avatar_url":"http://localhost/author/media/1234567890987654321b.jpg"
+                   }
+                ],
+                "feature_media":{
+                   "description":"Smoke on the water on River Gradac",
+                   "by_line":"Ljub. Z. Ranković",
+                   "alt_text":"Gradac alt text",
+                   "usage_terms":"indefinite-usage",
+                   "headline":"Smoke on the water",
+                   "copyright_holder":"Holder",
+                   "copyright_notice":"Notice",
+                   "license":{
+
+                   },
+                   "_links":{
+                      "download":{
+                         "href":"/media/20170111140132_979ff3c8a001d6cb2a7071eab9be852211853990f8d60e693e38f79e972772ea.png"
+                      }
+                   }
+                }
+             }
+          ]
+       }
+    }
+    """

--- a/features/search/public_search_api_endpoint.feature
+++ b/features/search/public_search_api_endpoint.feature
@@ -123,7 +123,7 @@ Feature: Public Search API endpoint
        "page":1,
        "limit":10,
        "pages":1,
-       "total":5,
+       "total":4,
        "_links":{
           "self":{
              "href":"/api/v2/search/articles/?page=1&limit=10"

--- a/features/search/public_search_api_endpoint.feature
+++ b/features/search/public_search_api_endpoint.feature
@@ -147,9 +147,6 @@ Feature: Public Search API endpoint
                    "slug":"technews"
                 },
                 "lead":"abstract",
-                "slideshows":[
-
-                ],
                 "updated_at":"2021-03-15T09:46:13+00:00",
                 "authors":[
                    {

--- a/src/SWP/Bundle/BridgeBundle/Resources/config/serializer/Model.Author.yml
+++ b/src/SWP/Bundle/BridgeBundle/Resources/config/serializer/Model.Author.yml
@@ -3,13 +3,13 @@ SWP\Component\Bridge\Model\Author:
     properties:
         name:
             type: string
-            groups: [api, api_article_authors]
+            groups: [api, api_article_authors, public_api]
         biography:
             type: string
             groups: [api, api_article_authors]
         role:
             type: string
-            groups: [api, api_article_authors]
+            groups: [api, api_article_authors, public_api]
         avatarUrl:
             type: string
             serialized_name: avatar_url

--- a/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.Article.yml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.Article.yml
@@ -82,10 +82,6 @@ SWP\Bundle\ContentBundle\Model\Article:
         authors:
             expose: true
             groups: [api, api_article_authors, public_api]
-        extra:
-            expose: true
-            groups: [api]
-            type: array
         slideshows:
             expose: true
             groups: [api, api_articles_slideshows]
@@ -96,6 +92,11 @@ SWP\Bundle\ContentBundle\Model\Article:
         previousRelativeUrls:
             expose: true
             groups: [api]
+    virtual_properties:
+        getExtraArray:
+            name: extra
+            serialized_name: extra
+            type: array
     relations:
         -
             rel: self

--- a/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.Article.yml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.Article.yml
@@ -7,26 +7,26 @@ SWP\Bundle\ContentBundle\Model\Article:
             type: integer
         title:
             expose: true
-            groups: [api, api_packages_list, api_articles_list]
+            groups: [api, api_packages_list, api_articles_list, public_api]
             type: string
         lead:
             expose: true
-            groups: [api, api_articles_list]
+            groups: [api, api_articles_list, public_api]
             type: string
         body:
             expose: true
-            groups: [api, api_articles_list]
+            groups: [api, api_articles_list, public_api]
             type: string
         slug:
             expose: true
-            groups: [api, api_articles_list]
+            groups: [api, api_articles_list, public_api]
             type: string
         route:
             expose: true
-            groups: [api, api_packages_list, api_articles_list]
+            groups: [api, api_packages_list, api_articles_list, public_api]
         publishedAt:
             expose: true
-            groups: [api, api_packages_list, api_articles_list]
+            groups: [api, api_packages_list, api_articles_list, public_api]
             type: DateTime
         status:
             expose: true
@@ -45,7 +45,7 @@ SWP\Bundle\ContentBundle\Model\Article:
             type: DateTime
         updatedAt:
             expose: true
-            groups: [api, api_packages_list, api_articles_list]
+            groups: [api, api_packages_list, api_articles_list, public_api]
             type: DateTime
         publishStartDate:
             expose: true
@@ -64,7 +64,7 @@ SWP\Bundle\ContentBundle\Model\Article:
             groups: [api]
         featureMedia:
             expose: true
-            groups: [api, api_articles_featuremedia]
+            groups: [api, api_articles_featuremedia, public_api]
         metadata:
             expose: true
             groups: [api]
@@ -81,10 +81,14 @@ SWP\Bundle\ContentBundle\Model\Article:
             type: string
         authors:
             expose: true
-            groups: [api, api_article_authors]
+            groups: [api, api_article_authors, public_api]
+        extra:
+            expose: true
+            groups: [api]
+            type: array
         slideshows:
             expose: true
-            groups: [api, api_articles_slideshows]
+            groups: [api, api_articles_slideshows, public_api]
             type: ArrayCollection
         seoMetadata:
             expose: true
@@ -99,6 +103,8 @@ SWP\Bundle\ContentBundle\Model\Article:
                 route: swp_api_content_show_articles
                 parameters:
                     id: "expr(object.getSlug())"
+            exclusion:
+                groups: [api]
         -
             rel: online
             href:
@@ -107,12 +113,14 @@ SWP\Bundle\ContentBundle\Model\Article:
                     slug: "expr(object.getSlug())"
             exclusion:
                 exclude_if: "expr(object.getRoute() !== null && object.getRoute().getType() !== 'collection')"
+                groups: [api]
         -
             rel: online
             href:
                 route: "expr(object.getRoute() ? object.getRoute().getRouteName() : 'swp_api_content_list_articles' )"
             exclusion:
                 exclude_if: "expr(object.getRoute() !== null && object.getRoute().getType() !== 'content')"
+                groups: [api]
         -
             rel: related
             href:
@@ -121,8 +129,4 @@ SWP\Bundle\ContentBundle\Model\Article:
                     id: "expr(object.getId())"
             exclusion:
                 exclude_if: "expr(null === object.getId())"
-    virtual_properties:
-        getExtraArray:
-            name: extra
-            serialized_name: extra
-            type: array
+                groups: [api]

--- a/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.Article.yml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.Article.yml
@@ -97,6 +97,7 @@ SWP\Bundle\ContentBundle\Model\Article:
             name: extra
             serialized_name: extra
             type: array
+            groups: [api]
     relations:
         -
             rel: self

--- a/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.Article.yml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.Article.yml
@@ -88,7 +88,7 @@ SWP\Bundle\ContentBundle\Model\Article:
             type: array
         slideshows:
             expose: true
-            groups: [api, api_articles_slideshows, public_api]
+            groups: [api, api_articles_slideshows]
             type: ArrayCollection
         seoMetadata:
             expose: true

--- a/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.ArticleAuthor.yml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.ArticleAuthor.yml
@@ -2,7 +2,7 @@ SWP\Bundle\ContentBundle\Model\ArticleAuthor:
     exclusion_policy: ALL
     properties:
         id:
-            type: string
+            type: int
             groups: [api, api_article_authors]
         avatar:
             groups: [api, api_article_authors]

--- a/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.ArticleAuthor.yml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.ArticleAuthor.yml
@@ -1,0 +1,11 @@
+SWP\Bundle\ContentBundle\Model\ArticleAuthor:
+    exclusion_policy: ALL
+    properties:
+        id:
+            type: string
+            groups: [api, api_article_authors]
+        avatar:
+            groups: [api, api_article_authors]
+        slug:
+            type: string
+            groups: [api, api_article_authors, public_api]

--- a/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.ArticleMedia.yml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.ArticleMedia.yml
@@ -16,31 +16,31 @@ SWP\Bundle\ContentBundle\Model\ArticleMedia:
             groups: [api, api_article_media_renditions]
         byLine:
             expose: true
-            groups: [api]
+            groups: [api, public_api]
         body:
             expose: true
-            groups: [api]
+            groups: [api, public_api]
             serialized_name: alt_text
         description:
             expose: true
-            groups: [api]
+            groups: [api, public_api]
         usageTerms:
             expose: true
-            groups: [api]
+            groups: [api, public_api]
         headline:
             expose: true
-            groups: [api]
+            groups: [api, public_api]
         copyrightNotice:
             expose: true
-            groups: [api]
+            groups: [api, public_api]
             type: string
         copyrightHolder:
             expose: true
-            groups: [api]
+            groups: [api, public_api]
             type: string
         license:
             expose: true
-            groups: [api]
+            groups: [api, public_api]
     relations:
         -
             rel: download

--- a/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.Route.yml
+++ b/src/SWP/Bundle/ContentBundle/Resources/config/serializer/Model.Route.yml
@@ -9,13 +9,13 @@ SWP\Bundle\ContentBundle\Model\Route:
             groups: [api, api_routes_list]
         name:
             expose: true
-            groups: [api, api_routes_list]
+            groups: [api, api_routes_list, public_api]
         description:
             expose: true
             groups: [api]
         slug:
             expose: true
-            groups: [api, api_routes_list]
+            groups: [api, api_routes_list, public_api]
         cacheTimeInSeconds:
             expose: true
             groups: [api]
@@ -55,6 +55,8 @@ SWP\Bundle\ContentBundle\Model\Route:
                 route: swp_api_content_show_routes
                 parameters:
                     id: expr(object.getId())
+          exclusion:
+              groups: [api]
         - rel: parent
           href:
                 route: swp_api_content_show_routes
@@ -62,3 +64,4 @@ SWP\Bundle\ContentBundle\Model\Route:
                     id: expr(object.getParent().getId())
           exclusion:
                 exclude_if: expr(null === object.getParent())
+                groups: [api]

--- a/src/SWP/Bundle/CoreBundle/Controller/ContentListItemController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/ContentListItemController.php
@@ -79,6 +79,7 @@ class ContentListItemController extends AbstractController
         $responseContext->setSerializationGroups(
             [
                 'Default',
+                'api',
                 'api_packages_list',
                 'api_content_list_item_details',
                 'api_articles_list',

--- a/src/SWP/Bundle/CoreBundle/Resources/config/serializer/Model.Article.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/serializer/Model.Article.yml
@@ -41,3 +41,4 @@ SWP\Bundle\CoreBundle\Model\Article:
                     articleId: "expr(object.getId())"
             exclusion:
                 exclude_if: "expr(object.getId() === null)"
+                groups: [api]

--- a/src/SWP/Bundle/ElasticSearchBundle/Controller/Api/PublicArticleSearchController.php
+++ b/src/SWP/Bundle/ElasticSearchBundle/Controller/Api/PublicArticleSearchController.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Superdesk Web Publisher ElasticSearch Bundle.
+ *
+ * Copyright 2021 Sourcefabric z.ú. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code.
+ *
+ * @copyright 2021 Sourcefabric z.ú
+ * @license http://www.superdesk.org/license
+ */
+
+namespace SWP\Bundle\ElasticSearchBundle\Controller\Api;
+
+use FOS\ElasticaBundle\Manager\RepositoryManagerInterface;
+use SWP\Bundle\CoreBundle\Model\ArticleInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class PublicArticleSearchController extends ArticleSearchController
+{
+    /**
+     * @Route("/api/{version}/search/articles/", methods={"GET"}, options={"expose"=true}, defaults={"version"="v2"}, name="swp_public_api_content_list_articles")
+     */
+    public function searchAction(Request $request, RepositoryManagerInterface $repositoryManager)
+    {
+        return parent::searchAction($request, $repositoryManager);
+    }
+
+    protected function getSerializationGroups(): array
+    {
+        return [
+            'Default',
+            'public_api',
+        ];
+    }
+
+    protected function createAdditionalCriteria(Request $request): array
+    {
+        return [
+            'statuses' => [ArticleInterface::STATUS_PUBLISHED],
+        ];
+    }
+}

--- a/src/SWP/Bundle/ElasticSearchBundle/Resources/config/controllers.yaml
+++ b/src/SWP/Bundle/ElasticSearchBundle/Resources/config/controllers.yaml
@@ -2,15 +2,10 @@ services:
   SWP\Bundle\ElasticSearchBundle\Controller\Api\ArticleSearchController:
     tags: ['controller.service_arguments']
     public: true
-    arguments:
-      - '@fos_elastica.manager'
 
   SWP\Bundle\ElasticSearchBundle\Controller\Api\PackageSearchController:
     tags: ['controller.service_arguments']
     public: true
-    arguments:
-      - '@fos_elastica.manager'
-
 
   SWP\Bundle\ElasticSearchBundle\Controller\Api\AuthorSearchController:
     tags: [ 'controller.service_arguments' ]
@@ -18,3 +13,7 @@ services:
     arguments:
       - '@fos_elastica.manager'
       - '%swp.model.author.class%'
+
+  SWP\Bundle\ElasticSearchBundle\Controller\Api\PublicArticleSearchController:
+    tags: [ 'controller.service_arguments' ]
+    public: true


### PR DESCRIPTION
## Reasons

Too much data were exposed from the internal API which was not needed. It was also possible to search for unpublished articles and search with more criteria.

## Proposed Changes
- limited querying the public search API endpoint
- limit data returned by the search API endpoint
- renamed endpoint

License: AGPLv3
