### PR TITLE
Convert image palette to truecolor before converting to webp

### DIFF
--- a/src/SWP/Bundle/CoreBundle/MessageHandler/ImageConversionHandler.php
+++ b/src/SWP/Bundle/CoreBundle/MessageHandler/ImageConversionHandler.php
@@ -106,6 +106,7 @@ class ImageConversionHandler implements MessageHandlerInterface
             if (null === $imageAsResource) {
                 throw new Exception('Could not get resource from provided images');
             }
+            imagepalettetotruecolor($imageAsResource);
             imagewebp($imageAsResource, $tempLocation);
             $uploadedFile = new UploadedFile($tempLocation, $mediaId, 'image/webp', strlen($tempLocation), null, true);
             $this->mediaManager->saveFile($uploadedFile, $mediaId);


### PR DESCRIPTION
## Reasons

`ImageConversionHandler.php` would crash on images in the color space _Adobe RGB (1998)_ with the error: `Paletter image not supported by webp`.

## Proposed Changes

Normalize the color space to truecolor before converting it to webp.

License: AGPLv3
