### PR TITLE
Urlencode subscription cache key

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Provider/CachedSubscriptionsProvider.php
+++ b/src/SWP/Bundle/CoreBundle/Provider/CachedSubscriptionsProvider.php
@@ -61,7 +61,7 @@ final class CachedSubscriptionsProvider implements SubscriptionsProviderInterfac
 
     public function getSubscriptions(SubscriberInterface $subscriber, array $filters = []): array
     {
-        $cacheKey = $this->generateCacheKey($subscriber).implode('_', $filters);
+        $cacheKey = urlencode($this->generateCacheKey($subscriber).implode('_', $filters));
 
         if ($this->cacheProvider->contains($cacheKey)) {
             $subscriptions = $this->cacheProvider->fetch($cacheKey);
@@ -76,7 +76,7 @@ final class CachedSubscriptionsProvider implements SubscriptionsProviderInterfac
 
     public function getSubscription(SubscriberInterface $subscriber, array $filters = []): ?SubscriptionInterface
     {
-        $cacheKey = $this->generateCacheKey($subscriber, self::CACHE_KEY_VALID).implode('_', $filters);
+        $cacheKey = urlencode($this->generateCacheKey($subscriber, self::CACHE_KEY_VALID).implode('_', $filters));
 
         if ($this->cacheProvider->contains($cacheKey)) {
             $subscription = $this->cacheProvider->fetch($cacheKey);


### PR DESCRIPTION
## Reasons

`CachedSubscriptionsProvider` will throw an error when the generated cache key contains a space.

```
Doctrine\Common\Cache\InvalidCacheId: Cache id "/var/www/publisher[subscription_provider_xxxxtest@example.com__NAME WITH SPACE][1]" contains unauthorized character " "
```

## Proposed Changes

Urlencode the generated cache key to ensure that it only contains valid characters.

License: AGPLv3
