### PR TITLE
Cancel article timestampable when updating mediaUpdatedAt

### DIFF
--- a/src/SWP/Bundle/CoreBundle/MessageHandler/ImageConversionHandler.php
+++ b/src/SWP/Bundle/CoreBundle/MessageHandler/ImageConversionHandler.php
@@ -134,7 +134,9 @@ class ImageConversionHandler implements MessageHandlerInterface
         /** @var ImageRenditionInterface[] $articleMedia */
         $articleMedia = $this->imageRenditionRepository->findBy(['image' => $image]);
         foreach ($articleMedia as $media) {
-            $media->getMedia()->getArticle()->setMediaUpdatedAt(new DateTime());
+            $article = $media->getMedia()->getArticle();
+            $article->setMediaUpdatedAt(new DateTime());
+            $article->cancelTimestampable(true);
         }
     }
 


### PR DESCRIPTION
## Reasons

Currently, article "updatedAt" is updated when images are successfully converted to webp. The expected behaviour would be to only update the "mediaUpdatedAt" field. This PR fixes #1215.

## Proposed Changes

Call `TimestampableCancelInterface.cancelTimestampable(true)` to cancel the automatic update of "updatedAt" field on article.

License: AGPLv3
