### PR TITLE
Fix SQLite errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
     "doctrine/doctrine-migrations-bundle": "^3.1",
     "doctrine/inflector": "^1.3",
     "doctrine/migrations": "^3.1",
-    "doctrine/orm": "^2.7",
+    "doctrine/orm": "^2.7 <2.13",
     "doctrine/phpcr-bundle": "^2.4",
     "doctrine/phpcr-odm": "^1.6",
     "emanueleminotto/twig-cache-bundle": "dev-master",

--- a/src/SWP/Bundle/BridgeBundle/composer.json
+++ b/src/SWP/Bundle/BridgeBundle/composer.json
@@ -42,7 +42,7 @@
         "symfony/stopwatch": "^5.4",
         "sensio/framework-extra-bundle": "^5.0",
         "doctrine/doctrine-bundle": "^2.0",
-        "doctrine/orm": "^2.7",
+        "doctrine/orm": "^2.7 <2.13",
         "swp/jms-serializer-bridge": "^2.0"
     },
     "config": {

--- a/src/SWP/Bundle/ContentBundle/composer.json
+++ b/src/SWP/Bundle/ContentBundle/composer.json
@@ -59,7 +59,8 @@
     "symfony/templating": "^5.4",
     "sentry/sentry-symfony": "^3.3 >3.3.1",
     "symfony/messenger": "^5.4",
-    "symfony/mime": "^5.4"
+    "symfony/mime": "^5.4",
+    "doctrine/orm": "^2.7 <2.13"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",
@@ -82,7 +83,6 @@
     "nelmio/alice": "3.5.*",
     "sensio/framework-extra-bundle": "^5.5",
     "twig/cache-extension": "^1.4",
-    "doctrine/orm": "^2.7",
     "dms/phpunit-arraysubset-asserts": "^0.4.0",
     "liip/test-fixtures-bundle": "^2.4",
     "doctrine/dbal": "^2.6"

--- a/src/SWP/Bundle/MultiTenancyBundle/composer.json
+++ b/src/SWP/Bundle/MultiTenancyBundle/composer.json
@@ -27,7 +27,7 @@
         "symfony/dependency-injection": "^4.2",
         "symfony/expression-language": "^4.2",
         "symfony-cmf/routing-bundle": "^2.0",
-        "doctrine/orm": "^2.6",
+        "doctrine/orm": "^2.7 <2.13",
         "symfony/form": "^4.2",
         "jackalope/jackalope": "^1.0@dev",
         "jackalope/jackalope-doctrine-dbal": "^1.3@dev"

--- a/src/SWP/Bundle/SettingsBundle/composer.json
+++ b/src/SWP/Bundle/SettingsBundle/composer.json
@@ -26,7 +26,7 @@
     "symfony/validator": "^5.4",
     "symfony/security-core": "^5.4",
     "sensio/framework-extra-bundle": "^5.5",
-    "doctrine/orm": "^2.7",
+    "doctrine/orm": "^2.7 <2.13",
     "doctrine/doctrine-bundle": "^1.10 | ^2.0"
   },
   "require-dev": {

--- a/src/SWP/Bundle/StorageBundle/composer.json
+++ b/src/SWP/Bundle/StorageBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/framework-bundle": "^4.2 | ^5.0",
         "symfony/doctrine-bridge": "^4.2 | ^5.0",
         "symfony/property-info": "^4.2 | ^5.0",
-        "doctrine/orm": "^2.7",
+        "doctrine/orm": "^2.7 <2.13",
         "doctrine/doctrine-bundle": "^2.0"
     },
     "require-dev": {

--- a/src/SWP/Bundle/UserBundle/composer.json
+++ b/src/SWP/Bundle/UserBundle/composer.json
@@ -48,7 +48,7 @@
     "symfony/security": "^4.2",
     "symfony/security-bundle": "^4.2",
     "symfony/doctrine-bridge": "^4.2",
-    "doctrine/orm": "^2.6",
+    "doctrine/orm": "^2.7 <2.13",
     "doctrine/doctrine-fixtures-bundle": "^3.0",
     "liip/functional-test-bundle": "^2.0",
     "sensio/framework-extra-bundle": "^5.0",


### PR DESCRIPTION
## Reasons
 doctrine/orm 2.13.1 released and gets picked by composer that doesnt work with the sqlite,
## Proposed Changes

License: AGPLv3
