### PR TITLE
Change FOS user interface with swp user bundle interface

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Factory/ApiKeyFactory.php
+++ b/src/SWP/Bundle/CoreBundle/Factory/ApiKeyFactory.php
@@ -14,7 +14,8 @@
 
 namespace SWP\Bundle\CoreBundle\Factory;
 
-use FOS\UserBundle\Model\UserInterface;
+use Exception;
+use SWP\Bundle\CoreBundle\Model\UserInterface;
 use SWP\Bundle\CoreBundle\Model\ApiKeyInterface;
 
 class ApiKeyFactory
@@ -36,11 +37,11 @@ class ApiKeyFactory
 
     /**
      * @param UserInterface $user
-     * @param string|null   $apiKeyValue
-     *
-     * @return mixed
+     * @param $apiKeyValue
+     * @return ApiKeyInterface
+     * @throws Exception
      */
-    public function create($user, $apiKeyValue = null)
+    public function create(UserInterface $user, $apiKeyValue = null)
     {
         /** @var ApiKeyInterface $apiKey */
         $apiKey = new $this->className();


### PR DESCRIPTION
## Reasons
Fix FOSUserBundle legacy code.  FOSUserBundle was remove in [this](https://github.com/superdesk/web-publisher/commit/f007be704b65c1e8fab5cf22c6a4ee93f9d87735) and it's replaced with SWPUserBundle.

## Proposed Changes

Replace  FOS\UserBundle\Model\UserInterface with SWP\Bundle\CoreBundle\Model\UserInterface.

License: AGPLv3
