### PR TITLE
Rule processor should process article on update, same as article publish

### DIFF
--- a/src/SWP/Bundle/ContentBundle/Controller/ContentPushController.php
+++ b/src/SWP/Bundle/ContentBundle/Controller/ContentPushController.php
@@ -49,16 +49,16 @@ class ContentPushController extends AbstractController {
   private PackageRepository $packageRepository;//swp.repository.package
   private FileProviderInterface $fileProvider;
 
-  /**
-   * @param EventDispatcherInterface $eventDispatcher
-   * @param FormFactoryInterface $formFactory
-   * @param MessageBusInterface $messageBus
-   * @param DataTransformerInterface $dataTransformer
-   * @param MediaManagerInterface $mediaManager
-   * @param EntityManagerInterface $entityManager
-   * @param PackageRepositoryInterface $packageRepository
-   * @param FileProviderInterface $fileProvider
-   */
+    /**
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param FormFactoryInterface $formFactory
+     * @param MessageBusInterface $messageBus
+     * @param DataTransformerInterface $dataTransformer
+     * @param MediaManagerInterface $mediaManager
+     * @param EntityManagerInterface $entityManager
+     * @param PackageRepository $packageRepository
+     * @param FileProviderInterface $fileProvider
+     */
   public function __construct(EventDispatcherInterface $eventDispatcher, FormFactoryInterface $formFactory,
                               MessageBusInterface      $messageBus,
                               DataTransformerInterface $dataTransformer, MediaManagerInterface $mediaManager,

--- a/src/SWP/Bundle/CoreBundle/EventSubscriber/ProcessArticleRulesSubscriber.php
+++ b/src/SWP/Bundle/CoreBundle/EventSubscriber/ProcessArticleRulesSubscriber.php
@@ -70,7 +70,7 @@ class ProcessArticleRulesSubscriber implements EventSubscriberInterface
         $article = $event->getArticle();
         $count = $this->publishDestinationProvider->countDestinations($package);
 
-        if (0 < $count || $article->isPublished()) {
+        if (0 < $count) {
             return;
         }
 


### PR DESCRIPTION
## Reasons

Some rules must be processed on article updated/correct

## Proposed Changes
Just trigger all rules, each rule applicator should handle his own execution and check  'isPublished' if necessary. 

License: AGPLv3
