### PR TITLE
Add extra catch-block for TypeErrors

### DIFF
--- a/src/SWP/Component/Rule/Evaluator/RuleEvaluator.php
+++ b/src/SWP/Component/Rule/Evaluator/RuleEvaluator.php
@@ -52,6 +52,8 @@ final class RuleEvaluator implements RuleEvaluatorInterface
             return (bool) $this->expression->evaluate($rule->getExpression(), [$subject->getSubjectType() => $subject]);
         } catch (\Exception $e) {
             $this->logger->error(sprintf('%s', $e->getMessage()), ['exception' => $e]);
+        } catch (\TypeError $e) {
+            $this->logger->error(sprintf('%s', $e->getMessage()), ['exception' => $e]);
         }
 
         return false;


### PR DESCRIPTION
## Reasons
In php 8.0 internal functions now throw errors instead of warnings which aren't getting caught by the normal catch block exception. So here we add a specific catch block for the TypeError so that the old behaviour is somewhat restored.

## Proposed Changes
Add TypeError catch to the evaluation calls in the RulesProcessor.

License: AGPLv3
