### PR TITLE
Take description_html instead of description_text

### DIFF
--- a/src/SWP/Bundle/BridgeBundle/Resources/config/serializer/Model.BaseContent.yml
+++ b/src/SWP/Bundle/BridgeBundle/Resources/config/serializer/Model.BaseContent.yml
@@ -81,7 +81,7 @@ SWP\Component\Bridge\Model\BaseContent:
             groups: [api]
         description:
             expose: true
-            serialized_name: description_text
+            serialized_name: description_html
             type: string
             groups: [api]
         keywords:

--- a/src/SWP/Bundle/CoreBundle/Tests/ContentPushTest.php
+++ b/src/SWP/Bundle/CoreBundle/Tests/ContentPushTest.php
@@ -749,7 +749,7 @@ final class ContentPushTest extends WebTestCase
 
         $content = json_decode($client->getResponse()->getContent(), true);
         self::assertArrayHasKey('lead', $content);
-        self::assertEquals('some abstract text', $content['lead']);
+        self::assertEquals('<p><b><u>some abstract text</u></b></p>', $content['lead']);
         self::assertArrayHasKey('keywords', $content);
         self::assertEquals(['name' => 'keyword1', 'slug' => 'keyword1'], $content['keywords'][0]);
         self::assertEquals(['name' => 'keyword2', 'slug' => 'keyword2'], $content['keywords'][1]);


### PR DESCRIPTION
## Reasons
When NINJS is pushed to the Publisher, `lead` is populated from the `description_text` in the incoming NINJS file. `description_text` contains text with stripped tags, meaning that no visual formatting or any other HTML that is set in Superdesk won't be reflected on the Publisher side. In other words, no formatting applied to Abstract text in Superdesk won't be visible in the Publisher.

## Proposed Changes
Take `description_html` instead of `description_text` from the incoming NINJS, as `description_html` contains all formatting and HTML that was used in Abstract field in Superdesk. 

License: AGPLv3
