### PR TITLE
Extending content lists webhook payload with modified articles

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Controller/ContentListItemController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/ContentListItemController.php
@@ -192,11 +192,20 @@ class ContentListItemController extends AbstractController {
       }
 
       $updatedArticles = [];
+      $updatedItemsInvalidateCache = [];
       /** @var ContentListAction $item */
       foreach ($data['items'] as $item) {
         $position = $item->getPosition();
         $isSticky = $item->isSticky();
         $contentId = $item->getContentId();
+
+        $updatedItemsInvalidateCache[] = [
+            'id' => $contentId,
+            'action' => $item->getAction(),
+            'sticky' => $item->isSticky(),
+            'postition' => $item->getPosition()
+        ];
+
 
         switch ($item->getAction()) {
           case ContentListAction::ACTION_MOVE:
@@ -268,7 +277,8 @@ class ContentListItemController extends AbstractController {
                 'id' => $list->getId(),
                 'name' => $list->getName(),
                 'type' => $list->getType(),
-                'action' => 'BATCH-UPDATE'
+                'action' => 'BATCH-UPDATE',
+                'items' => $updatedItemsInvalidateCache
             ]
         );
 


### PR DESCRIPTION
New output example:
`{
  "id": 30,
  "name": "Manual sandbox",
  "type": "manual",
  "action": "BATCH-UPDATE",
  "items": [
    {
      "id": 15925,
      "action": "add",
      "sticky": false,
      "postition": 7
    },
    {
      "id": 15794,
      "action": "move",
      "sticky": true,
      "postition": 4
    },
    {
      "id": 15913,
      "action": "delete",
      "sticky": false,
      "postition": 0
    }
  ]
}`

## Reasons

## Proposed Changes

License: AGPLv3
