### PR TITLE
Limiting Failed queue controller to 500 items

### DIFF
--- a/src/SWP/Bundle/CoreBundle/Controller/FailedQueueController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/FailedQueueController.php
@@ -27,8 +27,8 @@ class FailedQueueController extends AbstractController {
    * @Route("/api/{version}/failed_queue/", methods={"GET"}, options={"expose"=true}, defaults={"version"="v2"}, name="swp_api_core_list_failed_queue")
    */
   public function listAction(Request $request, FailedEntriesProvider $failedEntriesProvider) {
-    $max = $request->query->getInt('limit', 50);
-
-    return new SingleResourceResponse($failedEntriesProvider->getFailedEntries($max));
+    $requestedLimit = $request->query->getInt('limit', 50);
+    $max = max(1, min($requestedLimit, 500));
+    $failedEntries = $failedEntriesProvider->getFailedEntries($max);
   }
 }


### PR DESCRIPTION
There’s an issue with a huge limit that the Publisher extension sends: `/api/v2/failed_queue/?limit=9999`
However, limit of 9999 items makes no sense, hence, the endpoint is limited to 500 items, until the pagination is introduced. 
