### PR TITLE
Failed queue limit and ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -88,7 +88,7 @@ jobs:
           node-version: '12.x'
 
       - name: Cache NPM
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-node-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: echo "::set-output name=directory::$(composer config cache-dir)"
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.directory }}
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/src/SWP/Bundle/CoreBundle/Controller/FailedQueueController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/FailedQueueController.php
@@ -27,8 +27,16 @@ class FailedQueueController extends AbstractController {
    * @Route("/api/{version}/failed_queue/", methods={"GET"}, options={"expose"=true}, defaults={"version"="v2"}, name="swp_api_core_list_failed_queue")
    */
   public function listAction(Request $request, FailedEntriesProvider $failedEntriesProvider) {
-    $requestedLimit = $request->query->getInt('limit', 50);
-    $max = max(1, min($requestedLimit, 500));
-    $failedEntries = $failedEntriesProvider->getFailedEntries($max);
+      try {
+          $requestedLimit = $request->query->getInt('limit', 50);
+          $max = $requestedLimit > 500 ? 500 : $requestedLimit;
+          $entries = $failedEntriesProvider->getFailedEntries($max);
+          return new SingleResourceResponse($entries);
+      } catch (\Exception $e) {
+          return new SingleResourceResponse(
+              ['error' => 'An error occurred while retrieving failed entries'],
+              Response::HTTP_INTERNAL_SERVER_ERROR
+          );
+      }
   }
 }

--- a/src/SWP/Bundle/CoreBundle/Controller/FailedQueueController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/FailedQueueController.php
@@ -27,8 +27,8 @@ class FailedQueueController extends AbstractController {
    * @Route("/api/{version}/failed_queue/", methods={"GET"}, options={"expose"=true}, defaults={"version"="v2"}, name="swp_api_core_list_failed_queue")
    */
   public function listAction(Request $request, FailedEntriesProvider $failedEntriesProvider) {
-    $max = $request->query->getInt('limit', 50);
-
-    return new SingleResourceResponse($failedEntriesProvider->getFailedEntries($max));
+    $requestedLimit = $request->query->getInt('limit', 50);
+    $max = max(1, min($requestedLimit, 500));
+    $failedEntries = $failedEntriesProvider->getFailedEntries($max);
   }
 }

--- a/src/SWP/Bundle/CoreBundle/Controller/FailedQueueController.php
+++ b/src/SWP/Bundle/CoreBundle/Controller/FailedQueueController.php
@@ -30,7 +30,7 @@ class FailedQueueController extends AbstractController {
       try {
           $requestedLimit = $request->query->getInt('limit', 50);
           $max = $requestedLimit > 500 ? 500 : $requestedLimit;
-          $entries = $failedEntriesProvider->getFailedEntries($max);
+          $entries = $failedEntriesProvider->getFailedEntriesDescendingById($max);
           return new SingleResourceResponse($entries);
       } catch (\Exception $e) {
           return new SingleResourceResponse(

--- a/src/SWP/Bundle/CoreBundle/Provider/FailedEntriesProvider.php
+++ b/src/SWP/Bundle/CoreBundle/Provider/FailedEntriesProvider.php
@@ -74,7 +74,7 @@ class FailedEntriesProvider
 
     public function getFailedEntriesDescendingById(?int $max = null): array
     {
-        $envelopes = $this->receiver->all($max);
+        $envelopes = $this->receiver->all(null);
 
         $envelopesById = [];
         foreach ($envelopes as $envelope) {
@@ -87,8 +87,12 @@ class FailedEntriesProvider
         krsort($envelopesById);
 
         $rows = [];
+        $envelopeLimitCount = 0;
 
         foreach ($envelopesById as $id => $envelope) {
+
+            if ($envelopeLimitCount >= $max) { break; }
+
             /** @var SentToFailureTransportStamp|null $sentToFailureTransportStamp */
             $sentToFailureTransportStamp = $envelope->last(SentToFailureTransportStamp::class);
 
@@ -112,6 +116,8 @@ class FailedEntriesProvider
                 $envelope->getMessage() instanceof MessageInterface ? $envelope->getMessage()->toArray() : [],
                 $errorDetailsStamp?->getFlattenException()->getTraceAsString()
             );
+
+            $envelopeLimitCount++;
         }
 
         return $rows;

--- a/src/SWP/Bundle/CoreBundle/Provider/FailedEntriesProvider.php
+++ b/src/SWP/Bundle/CoreBundle/Provider/FailedEntriesProvider.php
@@ -71,4 +71,49 @@ class FailedEntriesProvider
 
         return $rows;
     }
+
+    public function getFailedEntriesDescendingById(?int $max = null): array
+    {
+        $envelopes = $this->receiver->all($max);
+
+        $envelopesById = [];
+        foreach ($envelopes as $envelope) {
+            /** @var TransportMessageIdStamp $stamp */
+            $stamp = $envelope->last(TransportMessageIdStamp::class);
+            $id = (int) $stamp->getId();
+            $envelopesById[$id] = $envelope;
+        }
+
+        krsort($envelopesById);
+
+        $rows = [];
+
+        foreach ($envelopesById as $id => $envelope) {
+            /** @var SentToFailureTransportStamp|null $sentToFailureTransportStamp */
+            $sentToFailureTransportStamp = $envelope->last(SentToFailureTransportStamp::class);
+
+            $history = [];
+            foreach (array_reverse($envelope->all(RedeliveryStamp::class)) as $redeliveryStamp) {
+                $history[] = $redeliveryStamp->getRedeliveredAt();
+            }
+
+            /**
+            * @var ErrorDetailsStamp $errorDetailsStamp
+            */
+            $errorDetailsStamp = $envelope->last(ErrorDetailsStamp::class);
+
+            $rows[] = new FailedEntry(
+                $id,
+                get_class($envelope->getMessage()),
+                $history[0] ?? null,
+                $errorDetailsStamp?->getExceptionMessage(),
+                $sentToFailureTransportStamp->getOriginalReceiverName(),
+                $history,
+                $envelope->getMessage() instanceof MessageInterface ? $envelope->getMessage()->toArray() : [],
+                $errorDetailsStamp?->getFlattenException()->getTraceAsString()
+            );
+        }
+
+        return $rows;
+    }
 }


### PR DESCRIPTION
Limiting Failed queue controller to 500 items, introducing `getFailedEntriesDescendingById` for returning failed queue items by ID, descending.  

Fixed `actions/cache@v1` and `actions/cache@v2` test errors.
