### PR TITLE
Accept attachments as an array instead of object

### DIFF
--- a/src/SWP/Component/Bridge/Validator/NinjsValidator.php
+++ b/src/SWP/Component/Bridge/Validator/NinjsValidator.php
@@ -404,7 +404,7 @@ class NinjsValidator extends JsonValidator
     },
     "attachments":{
       "description":"Wrapper for different attachments of non-textual content of the news object",
-      "type":"object",
+      "type":"array",
       "additionalProperties":false,
       "patternProperties":{
         "^[a-zA-Z0-9]+":{


### PR DESCRIPTION
## Reasons

Articles with attachments don not pass validation. They should go through (and be ignored), even though attachments are not handled in the Publisher

## Proposed Changes

Setting `"type":"array"` in the validator for attachments.

License: AGPLv3
